### PR TITLE
Handle nested exceptions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ end
 desc 'Run Test Suite'
 task :test do
   Rake::TestTask.new(:functional) do |t|
-    t.test_files = FileList['test/*_test.rb']
+    t.test_files = FileList['test/**/*_test.rb']
     t.verbose    = true
   end
 

--- a/lib/semantic_logger/appender/base.rb
+++ b/lib/semantic_logger/appender/base.rb
@@ -81,7 +81,7 @@ module SemanticLogger
             if i == 0
               message << ' -- Exception: '
             else
-              message << "\nCause Exception: "
+              message << "\nCause: "
             end
             message << "#{colors::BOLD}#{exception.class}: #{exception.message}#{colors::CLEAR}\n#{(exception.backtrace || []).join("\n")}"
           end

--- a/lib/semantic_logger/appender/base.rb
+++ b/lib/semantic_logger/appender/base.rb
@@ -36,16 +36,25 @@ module SemanticLogger
 
           message = log.message.to_s.dup
           message << ' -- ' << log.payload.inspect unless log.payload.nil? || (log.payload.respond_to?(:empty?) && log.payload.empty?)
-          message << ' -- Exception: ' << "#{log.exception.class}: #{log.exception.message}\n#{(log.exception.backtrace || []).join("\n")}" if log.exception
+          log.each_exception do |exception, i|
+            if i == 0
+              message << ' -- Exception: '
+            else
+              message << "\nCause: "
+            end
+            message << "#{exception.class}: #{exception.message}\n#{(exception.backtrace || []).join("\n")}"
+          end
 
           duration_str = log.duration ? "(#{'%.1f' % log.duration}ms) " : ''
 
           file_name =
             if log.backtrace || log.exception
               backtrace  = log.backtrace || log.exception.backtrace
-              location   = backtrace[0].split('/').last
-              file, line = location.split(':')
-              " #{file}:#{line}"
+              if backtrace
+                location   = backtrace[0].split('/').last
+                file, line = location.split(':')
+                " #{file}:#{line}"
+              end
             end
 
           "#{SemanticLogger::Appender::Base.formatted_time(log.time)} #{log.level.to_s[0..0].upcase} [#{$$}:#{'%.50s' % log.thread_name}#{file_name}] #{tags}#{duration_str}#{log.name} -- #{message}"
@@ -54,7 +63,7 @@ module SemanticLogger
 
       # Optional log formatter to colorize log output
       # To use this formatter
-      #   SemanticLogger.add_appender($stdout, nil, &SemanticLogger::Logger.colorized_formatter)
+      #   SemanticLogger.add_appender($stdout, &SemanticLogger::Appender::Base.colorized_formatter)
       #
       #    2011-07-19 14:36:15.660 D [1149:ScriptThreadProcess] Rails -- Hello World
       def self.colorized_formatter
@@ -68,7 +77,14 @@ module SemanticLogger
             payload = (defined?(AwesomePrint) && payload.respond_to?(:ai)) ? payload.ai(multiline: false) : payload.inspect
             message << ' -- ' << payload
           end
-          message << ' -- Exception: ' << "#{colors::BOLD}#{log.exception.class}: #{log.exception.message}#{colors::CLEAR}\n#{(log.exception.backtrace || []).join("\n")}" if log.exception
+          log.each_exception do |exception, i|
+            if i == 0
+              message << ' -- Exception: '
+            else
+              message << "\nCause Exception: "
+            end
+            message << "#{colors::BOLD}#{exception.class}: #{exception.message}#{colors::CLEAR}\n#{(exception.backtrace || []).join("\n")}"
+          end
 
           duration_str = log.duration ? "(#{colors::BOLD}#{'%.1f' % log.duration}ms#{colors::CLEAR}) " : ''
 

--- a/lib/semantic_logger/appender/syslog.rb
+++ b/lib/semantic_logger/appender/syslog.rb
@@ -239,7 +239,14 @@ module SemanticLogger
 
           message = log.message.to_s
           message << ' -- ' << log.payload.inspect if log.payload
-          message << ' -- ' << "#{log.exception.class}: #{log.exception.message}\n#{(log.exception.backtrace || []).join("\n")}" if log.exception
+          log.each_exception do |exception, i|
+            if i == 0
+              message << ' -- '
+            else
+              message << "\nCause: "
+            end
+            message << "#{exception.class}: #{exception.message}\n#{(exception.backtrace || []).join("\n")}"
+          end
 
           duration_str = log.duration ? "(#{'%.1f' % log.duration}ms) " : ''
 

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -317,7 +317,45 @@ module SemanticLogger
     #
     # backtrace [Array<String>]
     #   The backtrace captured at source when the log level >= SemanticLogger.backtrace_level
-    Log = Struct.new(:level, :thread_name, :name, :message, :payload, :time, :duration, :tags, :level_index, :exception, :metric, :backtrace)
+    Log = Struct.new(:level, :thread_name, :name, :message, :payload, :time, :duration, :tags, :level_index, :exception, :metric, :backtrace) do
+      MAX_EXCEPTIONS_TO_UNWRAP = 5
+      # Call the block for exception and any nested exception
+      def each_exception(&block)
+        # Code mostly ripped off from bugsnag (See https://github.com/bugsnag/bugsnag-ruby/blob/6348306e44323eee347896843d16c690cd7c4362/lib/bugsnag/notification.rb#L81)
+        i          = 0
+        exceptions = []
+        ex         = exception
+        while ex != nil && !exceptions.include?(ex) && exceptions.length < MAX_EXCEPTIONS_TO_UNWRAP
+
+          unless ex.is_a? Exception
+            if ex.respond_to?(:to_exception)
+              ex = ex.to_exception
+            elsif ex.respond_to?(:exception)
+              ex = ex.exception
+            end
+          end
+
+          unless ex.is_a?(Exception) || (defined?(Java::JavaLang::Throwable) && ex.is_a?(Java::JavaLang::Throwable))
+            ex = RuntimeError.new(ex.to_s)
+            ex.set_backtrace caller
+          end
+
+          exceptions << ex
+          yield ex, i
+          i += 1
+
+          if ex.respond_to?(:cause) && ex.cause
+            ex = ex.cause
+          elsif ex.respond_to?(:continued_exception) && ex.continued_exception
+            ex = ex.continued_exception
+          elsif ex.respond_to?(:original_exception) && ex.original_exception
+            ex = ex.original_exception
+          else
+            ex = nil
+          end
+        end
+      end
+    end
 
     # Whether to log the supplied message based on the current filter if any
     def include_message?(struct)

--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -326,20 +326,6 @@ module SemanticLogger
         exceptions = []
         ex         = exception
         while ex != nil && !exceptions.include?(ex) && exceptions.length < MAX_EXCEPTIONS_TO_UNWRAP
-
-          unless ex.is_a? Exception
-            if ex.respond_to?(:to_exception)
-              ex = ex.to_exception
-            elsif ex.respond_to?(:exception)
-              ex = ex.exception
-            end
-          end
-
-          unless ex.is_a?(Exception) || (defined?(Java::JavaLang::Throwable) && ex.is_a?(Java::JavaLang::Throwable))
-            ex = RuntimeError.new(ex.to_s)
-            ex.set_backtrace caller
-          end
-
           exceptions << ex
           yield ex, i
           i += 1

--- a/test/appender/splunk_test.rb
+++ b/test/appender/splunk_test.rb
@@ -1,4 +1,4 @@
-require_relative 'test_helper'
+require_relative '../test_helper'
 
 # Unit Test for SemanticLogger::Appender::Splunk
 #


### PR DESCRIPTION
Added logging for nested exceptions for file and syslog appenders.  Bugsnag already handles this (I know because I stole there code).  Didn't address for mongodb, new_relic or splunk. 
Run all tests from rake.
Some test fixes.