### PR TITLE
Support for logging to Riemann

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,7 @@ gem 'gelf'
 gem 'honeybadger'
 # [optional] Statsd metrics
 gem 'statsd-ruby'
+# [optional] Riemann metrics and appender
+gem 'riemann-client'
 
 gem 'awesome_print'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ gem 'honeybadger'
 # [optional] Statsd metrics
 gem 'statsd-ruby'
 # [optional] Riemann metrics and appender
-gem 'riemann-client'
+gem 'riemann-ruby-experiments'
 
 gem 'awesome_print'

--- a/lib/semantic_logger.rb
+++ b/lib/semantic_logger.rb
@@ -34,6 +34,7 @@ module SemanticLogger
     autoload :Http,             'semantic_logger/appender/http'
     autoload :MongoDB,          'semantic_logger/appender/mongodb'
     autoload :NewRelic,         'semantic_logger/appender/new_relic'
+    autoload :Riemann,          'semantic_logger/appender/riemann'
     autoload :Splunk,           'semantic_logger/appender/splunk'
     autoload :SplunkHttp,       'semantic_logger/appender/splunk_http'
     autoload :Syslog,           'semantic_logger/appender/syslog'

--- a/lib/semantic_logger/appender/riemann.rb
+++ b/lib/semantic_logger/appender/riemann.rb
@@ -90,8 +90,9 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
 
   # Send an event to Riemann
   def log(log)
-    return false unless should_log?(log)
+    #return false unless should_log?(log)
     event = formatter.call(log, self)
+    event[:should_log] = should_log?(log).to_s
 
     # For more documentation on sending events to Riemann, see:
     # https://github.com/riemann/riemann-ruby-client

--- a/lib/semantic_logger/appender/riemann.rb
+++ b/lib/semantic_logger/appender/riemann.rb
@@ -1,7 +1,7 @@
 begin
-  require "riemann/client"
+  require "riemann-ruby-experiments"
 rescue LoadError
-  raise "Gem riemann-client is required for logging to Riemann. Please add the gem 'riemann-client' to your gemfile."
+  raise "Gem riemann-ruby-experiments is required for logging to Riemann. Please add the gem 'riemann-ruby-experiments' to your gemfile."
 end
 
 # Send log messages to a Riemann server
@@ -9,24 +9,15 @@ end
 # Example:
 #   SemanticLogger.add_appender(appender: :riemann)
 class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
-  attr_reader :riemann_hostname, :riemann_port
+  # Read up on Riemann::Experiment::Client and Net::TCPClient before tweaking this!
+  attr_accessor :riemann_opts
+
   # Create Riemann appender
   #
   # Parameters
-  #   riemann_hostname: [String]
-  #     Hostname of Riemann server to receive logs
-  #     Default: "localhost"
-  #
-  #   riemann_port: [Fixnum]
-  #     Port of Riemann server to receive logs
-  #     Default: 5555
-  #
-  #   protocol: [:tcp | :udp]
-  #     Send messages to Riemann server using this protocol
-  #
-  #   timeout: [Fixnum]
-  #     Time in seconds to timeout on sending to server
-  #     Default: 5
+  #   riemann_server: [String]
+  #     Hostname and port of Riemann server to receive logs
+  #     Default: "localhost:5555"
   #
   #   host: [String]
   #     Set the default hostname to be identified in events
@@ -38,7 +29,7 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
   #
   #   ttl: [Fixnum]
   #     Set the TTL field to be sent with the event.
-  #     Default: 60
+  #     Default: unincluded in message
   #
   #   level: [:trace | :debug | :info | :warn | :error | :fatal]
   #     Override the log level for this appender.
@@ -51,23 +42,37 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
   #     NOTE: Not just any formatter will do here, it must return a hash.
   #     Default: Use the built-in 'raw' formatter (See: #call)
   #
+  #  Other options with names that begin with "riemann_socket_" will be given
+  #  the remainder of the name as corresponding parameters to Net::TCPClient.new().
+  #  See the documentation there for options involving timeouts, etc.
   def initialize(options = {}, &block)
-    @options = options.dup
-    @riemann_host = options.delete(:riemann_hostname) || "localhost"
-    @riemann_port = options.delete(:riemann_port) || 5555
-    @protocol = options.delete(:protocol) || :tcp
-    @timeout = options.delete(:timeout) || 5
-    @ttl = options.delete(:ttl) || 60
-    @riemann = Riemann::Client.new(host: @riemann_host, port: @riemann_port, timeout: @timeout)
+    @riemann_opts = {}
+    @riemann_opts[:server] = options.delete(:riemann_server) || "localhost:5555"
+    @riemann_opts[:host]    = options.delete(:host) || SemanticLogger.host
+    @riemann_opts[:service] = options.delete(:service) || SemanticLogger.application
+    if options[:ttl]
+      @riemann_opts[:ttl] = options.delete(:ttl)
+    end
+    rx = /^riemann_socket_/
+    options.select {|k, v| rx.match(k.to_s) }.each {|k, v|
+      m = rx.match(k.to_s)
+      options.delete(k)
+      if m
+        @riemann_opts[m.post_match.to_sym] = v
+      end
+    }
 
-    options[:level] = :error unless options.has_key?(:level)
+    @options = options.dup
+    @riemann = Riemann::Experiment::Client.new(@riemann_opts)
+
+    options[:level] = :info unless options.has_key?(:level)
     super(options, &block)
   end
 
   # After forking an active process call #reopen to re-open
   # open the handles to resources
   def reopen
-    @riemann = Riemann::Client.new(host: @riemann_host, port: @riemann_port, timeout: @timeout)
+    @riemann = Riemann::Experiment::Client.new(@riemann_opts)
   end
 
   def default_formatter
@@ -78,13 +83,12 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
   def call(log, logger)
     h = log.to_h(host, application)
     # Standard keys
-    h[:service] = h.delete(:name)
+    h[:service] = h.delete(:name) || @riemann_opts[:service]
     h[:description] = h.delete(:message)
-    h[:time] = h[:time].to_i unless h[:time].nil?
+    h[:time] = h[:time].to_i unless h[:time].nil? # will be included by client if not.
     h[:state] = h.delete(:level).to_s
-    h.delete(:tags) if h[:tags].nil?
+    h.delete(:tags) if h[:tags].nil? || (h[:tags].length == 0)
     h.delete(:metric) if h[:metric].nil?
-    h[:ttl] ||= @ttl
     h
   end
 
@@ -95,12 +99,7 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
     event[:should_log] = should_log?(log).to_s
 
     # For more documentation on sending events to Riemann, see:
-    # https://github.com/riemann/riemann-ruby-client
-    if @protocol == :tcp
-      @riemann.tcp << event
-    else
-      @riemann.udp << event
-    end
-    true
+    # https://github.com/riddochc/riemann-ruby-experiments
+    @riemann.send_event(event).ok
   end
 end

--- a/lib/semantic_logger/appender/riemann.rb
+++ b/lib/semantic_logger/appender/riemann.rb
@@ -1,0 +1,105 @@
+begin
+  require "riemann/client"
+rescue LoadError
+  raise "Gem riemann-client is required for logging to Riemann. Please add the gem 'riemann-client' to your gemfile."
+end
+
+# Send log messages to a Riemann server
+#
+# Example:
+#   SemanticLogger.add_appender(appender: :riemann)
+class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
+  attr_reader :riemann_hostname, :riemann_port
+  # Create Riemann appender
+  #
+  # Parameters
+  #   riemann_hostname: [String]
+  #     Hostname of Riemann server to receive logs
+  #     Default: "localhost"
+  #
+  #   riemann_port: [Fixnum]
+  #     Port of Riemann server to receive logs
+  #     Default: 5555
+  #
+  #   protocol: [:tcp | :udp]
+  #     Send messages to Riemann server using this protocol
+  #
+  #   timeout: [Fixnum]
+  #     Time in seconds to timeout on sending to server
+  #     Default: 5
+  #
+  #   host: [String]
+  #     Set the default hostname to be identified in events
+  #     Default: SemanticLogger.host
+  #
+  #   service: [String]
+  #     Set the default service to be identified in events
+  #     Default: SemanticLogger.application
+  #
+  #   ttl: [Fixnum]
+  #     Set the TTL field to be sent with the event.
+  #     Default: 60
+  #
+  #   level: [:trace | :debug | :info | :warn | :error | :fatal]
+  #     Override the log level for this appender.
+  #     This will be included in events as the value of the "state" field.
+  #     Default: SemanticLogger.default_level
+  #
+  #   formatter: [Object | Proc]
+  #     An instance of a class that implements #call, or a Proc to be used to format
+  #     the output from this subscriber.
+  #     NOTE: Not just any formatter will do here, it must return a hash.
+  #     Default: Use the built-in 'raw' formatter (See: #call)
+  #
+  def initialize(options = {}, &block)
+    @options = options.dup
+    @riemann_host = options.delete(:riemann_hostname) || "localhost"
+    @riemann_port = options.delete(:riemann_port) || 5555
+    @protocol = options.delete(:protocol) || :tcp
+    @timeout = options.delete(:timeout) || 5
+    @ttl = options.delete(:ttl) || 60
+    @riemann = Riemann::Client.new(host: @riemann_host, port: @riemann_port, timeout: @timeout)
+
+    options[:level] = :error unless options.has_key?(:level)
+    super(options, &block)
+  end
+
+  # After forking an active process call #reopen to re-open
+  # open the handles to resources
+  def reopen
+    @riemann = Riemann::Client.new(host: @riemann_host, port: @riemann_port, timeout: @timeout)
+  end
+
+  def default_formatter
+    SemanticLogger::Formatters::Raw.new
+  end
+
+  # Returns [Hash] of parameters to send to Riemann
+  def call(log, logger)
+    h = log.to_h(host, application)
+    # Standard keys
+    h[:service] = h.delete(:name)
+    h[:description] = h.delete(:message)
+    h[:time] = h[:time].to_i unless h[:time].nil?
+    h[:state] = h.delete(:level).to_s
+    h.delete(:tags) if h[:tags].nil?
+    h.delete(:metric) if h[:metric].nil?
+    h[:ttl] ||= @ttl
+    h
+  end
+
+  # Send an event to Riemann
+  def log(log)
+    return false unless should_log?(log)
+    event = formatter.call(log, self)
+
+    # For more documentation on sending events to Riemann, see:
+    # https://github.com/riemann/riemann-ruby-client
+    if @protocol == :tcp
+      @riemann.tcp << event
+    else
+      @riemann.udp << event
+    end
+    true
+  end
+end

--- a/lib/semantic_logger/appender/riemann.rb
+++ b/lib/semantic_logger/appender/riemann.rb
@@ -94,9 +94,9 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
 
   # Send an event to Riemann
   def log(log)
-    #return false unless should_log?(log)
+    return false unless should_log?(log)
     event = formatter.call(log, self)
-    event[:should_log] = should_log?(log).to_s
+    # event[:should_log] = should_log?(log).to_s
 
     # For more documentation on sending events to Riemann, see:
     # https://github.com/riddochc/riemann-ruby-experiments

--- a/lib/semantic_logger/appender/riemann.rb
+++ b/lib/semantic_logger/appender/riemann.rb
@@ -132,6 +132,7 @@ class SemanticLogger::Appender::Riemann < SemanticLogger::Subscriber
 
     # For more documentation on sending events to Riemann, see:
     # https://github.com/riddochc/riemann-ruby-experiments
-    @riemann.send_event(event).ok
+    @riemann.add_event(event)
+    @riemann.send_message(ok: true)
   end
 end

--- a/test/appender/riemann_test.rb
+++ b/test/appender/riemann_test.rb
@@ -6,19 +6,22 @@ module Appender
   class Riemann < MiniTest::Test
     describe SemanticLogger::Appender::Riemann do
       before do
-        @appender = SemanticLogger::Appender::Riemann.new()
+        @appender = SemanticLogger::Appender::Riemann.new(riemann_server: "localhost:5555")
         SemanticLogger.default_level = :info
-        SemanticLogger.add_appender(appender: :riemann)
-        SemanticLogger.application = "MiniTest"
-        @logger = SemanticLogger['RiemannTest']
-        # @reciever = Riemann::Client.new(host: "localhost", port: 5555, timeout: 5)
-        #SemanticLogger.add_appender(appender: @appender)
-        #@logger = SemanticLogger["RiemannTest"]
+        SemanticLogger.add_appender(appender: @appender)
+        SemanticLogger.application = "SomeApp"
+        @logger = SemanticLogger["RiemannTest"]
       end
 
       it "sends info" do
-        @appender.send(:debug, "Halp!")
-        #@logger.debug("Halp!")
+        @logger.info("Halp!")
+      end
+
+      it "measures things" do
+        @logger.measure_info("sleeping a tiny bit") do
+          sleep 0.1
+          42
+        end
       end
     end
   end

--- a/test/appender/riemann_test.rb
+++ b/test/appender/riemann_test.rb
@@ -1,0 +1,25 @@
+require_relative "../test_helper"
+require 'tracer'
+
+# Unit Test for Riemann
+module Appender
+  class Riemann < MiniTest::Test
+    describe SemanticLogger::Appender::Riemann do
+      before do
+        @appender = SemanticLogger::Appender::Riemann.new()
+        SemanticLogger.default_level = :info
+        SemanticLogger.add_appender(appender: :riemann)
+        SemanticLogger.application = "MiniTest"
+        @logger = SemanticLogger['RiemannTest']
+        # @reciever = Riemann::Client.new(host: "localhost", port: 5555, timeout: 5)
+        #SemanticLogger.add_appender(appender: @appender)
+        #@logger = SemanticLogger["RiemannTest"]
+      end
+
+      it "sends info" do
+        @appender.send(:debug, "Halp!")
+        #@logger.debug("Halp!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've implemented support for sending logs as events to a Riemann server: http://riemann.io/

Also, thanks for semantic_logger, and semantic_logger_rails. Right now, it's exactly what I want out of a logging API... I was just about ready to start writing something very similar myself, but then discovered this project.
