### PR TITLE
Adds appender for Sentry (Raven)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,7 @@ gem 'gelf'
 gem 'honeybadger'
 # [optional] Statsd metrics
 gem 'statsd-ruby'
+# [optional] Sentry appender
+gem 'sentry-raven'
 
 gem 'awesome_print'

--- a/lib/semantic_logger.rb
+++ b/lib/semantic_logger.rb
@@ -31,6 +31,7 @@ module SemanticLogger
     autoload :File,             'semantic_logger/appender/file'
     autoload :Graylog,          'semantic_logger/appender/graylog'
     autoload :Honeybadger,      'semantic_logger/appender/honeybadger'
+    autoload :Sentry,           'semantic_logger/appender/sentry'
     autoload :Http,             'semantic_logger/appender/http'
     autoload :MongoDB,          'semantic_logger/appender/mongodb'
     autoload :NewRelic,         'semantic_logger/appender/new_relic'

--- a/lib/semantic_logger/appender/sentry.rb
+++ b/lib/semantic_logger/appender/sentry.rb
@@ -1,0 +1,72 @@
+begin
+  require 'sentry-raven'
+rescue LoadError
+  raise 'Gem sentry-raven is required for logging purposes. Please add the gem "sentry-raven" to your Gemfile.'
+end
+
+# Send log messages to sentry
+#
+# Example:
+#   SemanticLogger.add_appender(appender: :sentry)
+#
+class SemanticLogger::Appender::Sentry < SemanticLogger::Subscriber
+  # Create Appender
+  #
+  # Parameters
+  #   level: [:trace | :debug | :info | :warn | :error | :fatal]
+  #     Override the log level for this appender.
+  #     Default: :error
+  #
+  #   formatter: [Object|Proc|Symbol|Hash]
+  #     An instance of a class that implements #call, or a Proc to be used to format
+  #     the output from this appender
+  #     Default: Use the built-in formatter (See: #call)
+  #
+  #   filter: [Regexp|Proc]
+  #     RegExp: Only include log messages where the class name matches the supplied.
+  #     regular expression. All other messages will be ignored.
+  #     Proc: Only include log messages where the supplied Proc returns true
+  #           The Proc must return true or false.
+  #
+  #   host: [String]
+  #     Name of this host to appear in log messages.
+  #     Default: SemanticLogger.host
+  #
+  #   application: [String]
+  #     Name of this application to appear in log messages.
+  #     Default: SemanticLogger.application
+  def initialize(options = {}, &block)
+    options         = options.is_a?(Hash) ? options.dup : {level: options}
+    options[:level] ||= :error
+
+    super(options, &block)
+  end
+
+  # Send an error notification to sentry
+  def log(log)
+    return false unless should_log?(log)
+
+    context = formatter.call(log, self)
+    if log.exception
+      context.delete(:exception)
+      Raven.capture_exception(log.exception, context)
+    else
+      message = {
+        error_class:   context.delete(:name),
+        error_message: context.delete(:message),
+        context: context
+      }
+      message[:backtrace] = log.backtrace if log.backtrace
+      Raven.capture_message(message[:error_message], message)
+    end
+    true
+  end
+
+  private
+
+  # Use Raw Formatter by default
+  def default_formatter
+    SemanticLogger::Formatters::Raw.new
+  end
+
+end

--- a/test/appender/sentry_test.rb
+++ b/test/appender/sentry_test.rb
@@ -1,0 +1,46 @@
+require_relative '../test_helper'
+
+# Unit Test for SemanticLogger::Appender::Bugsnag
+module Appender
+  class SentryTest < Minitest::Test
+    describe SemanticLogger::Appender::Sentry do
+      before do
+        @appender = SemanticLogger::Appender::Sentry.new(:trace)
+        @message  = 'AppenderRavenTest log message'
+        SemanticLogger.backtrace_level = :error
+      end
+
+      SemanticLogger::LEVELS.each do |level|
+        it "sends #{level} message" do
+          error_message = hash = nil
+          Raven.stub(:capture_message, -> msg, h { error_message = msg; hash = h }) do
+            @appender.send(level, @message)
+          end
+          assert_equal @message, hash[:error_message]
+          assert_equal 'SemanticLogger::Appender::Sentry', hash[:error_class]
+
+          if [:error, :fatal].include?(level)
+            assert hash.has_key?(:backtrace)
+          else
+            refute hash.has_key?(:backtrace)
+          end
+          assert_equal true, hash.has_key?(:context)
+          assert_equal level, hash[:context][:level]
+        end
+
+        it "sends #{level} exceptions" do
+          error     = RuntimeError.new('Oh no, Error.')
+          exception = hash = nil
+          Raven.stub(:capture_exception, -> exc, h { exception = exc; hash = h }) do
+            @appender.send(level, @message, error)
+          end
+
+          assert_equal error.class.to_s, exception.class.to_s
+          assert_equal error.message, exception.message
+          assert_equal @message, hash[:message], hash
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
We were missing an appender for Sentry and thought it is better to share the appender in case someone else needs it. This is just a first version of the appender and the intention with the pull request at this stage is to get some feedback.

Not sure why they call it sentry-raven as I find it very confusing so I decided to keep just sentry. Could easily be changed should anyone wish for it.