### PR TITLE
Force UTF-8 encoding for host names

### DIFF
--- a/lib/semantic_logger/formatters/json.rb
+++ b/lib/semantic_logger/formatters/json.rb
@@ -14,6 +14,9 @@ module SemanticLogger
         h = super(log, logger)
         h.delete(:time)
         h[:timestamp] = format_time(log.time)
+         # host names may contain non UTF-8 characters
+         # that will cause JSON serialization to fail
+        h[:host] = h[:host].force_encoding('UTF-8')
         h.to_json
       end
 


### PR DESCRIPTION
Some OSs will allow host names that are not UTF-8 compatible, which will cause JSON serialization to fail.  Force the name to UTF-8 before serializing.