### PR TITLE
Fix graylog duration parsing error

### DIFF
--- a/lib/semantic_logger/appender/graylog.rb
+++ b/lib/semantic_logger/appender/graylog.rb
@@ -103,6 +103,7 @@ class SemanticLogger::Appender::Graylog < SemanticLogger::Subscriber
     h[:timestamp]     = log.time.utc.to_f
     h[:level]         = logger.map_level(log)
     h[:level_str]     = log.level.to_s
+    h[:duration_str]  = h.delete(:duration)
     h[:short_message] = h.delete(:message) if log.message
     h
   end


### PR DESCRIPTION
Graylog was unable to parse current payload with this error:

`MapperParsingException[failed to parse [duration]]`

http://docs.graylog.org/en/2.1/pages/indexer_failures.html

It has a duration field of type number.

Here is my suggestion for renaming this field just for graylog