### PR TITLE
fix graylog appender if logger called only with exception object

### DIFF
--- a/lib/semantic_logger/appender/graylog.rb
+++ b/lib/semantic_logger/appender/graylog.rb
@@ -100,11 +100,14 @@ class SemanticLogger::Appender::Graylog < SemanticLogger::Subscriber
   def call(log, logger)
     h = log.to_h(host, application)
     h.delete(:time)
+    h.delete(:message) if log.message
+
+    short_message = log.message || log.exception.message
     h[:timestamp]     = log.time.utc.to_f
     h[:level]         = logger.map_level(log)
     h[:level_str]     = log.level.to_s
     h[:duration_str]  = h.delete(:duration)
-    h[:short_message] = h.delete(:message) if log.message
+    h[:short_message] = short_message
     h
   end
 

--- a/test/appender/graylog_test.rb
+++ b/test/appender/graylog_test.rb
@@ -30,9 +30,27 @@ module Appender
         @appender.notifier.stub(:notify!, -> h { hash = h }) do
           @appender.error 'Reading File', exc
         end
-        assert 'Reading File', hash[:short_message]
-        assert 'NameError', hash[:exception][:name]
-        assert 'undefined local variable or method', hash[:exception][:message]
+        assert_equal 'Reading File', hash[:short_message]
+        assert_equal 'NameError', hash[:exception][:name]
+        assert_match 'undefined local variable or method', hash[:exception][:message]
+        assert_equal 3, hash[:level], 'Should be error level (3)'
+        assert hash[:exception][:stack_trace].first.include?(__FILE__), hash[:exception]
+      end
+
+      it 'send exception notifications to Graylog without log message' do
+        hash = nil
+        exc  = nil
+        begin
+          raise StandardError, 'Reading File'
+        rescue Exception => e
+          exc = e
+        end
+        @appender.notifier.stub(:notify!, -> h { hash = h }) do
+          @appender.error exc
+        end
+        assert_equal exc.message, hash[:short_message]
+        assert_equal exc.class.to_s, hash[:exception][:name]
+        assert_match exc.message, hash[:exception][:message]
         assert_equal 3, hash[:level], 'Should be error level (3)'
         assert hash[:exception][:stack_trace].first.include?(__FILE__), hash[:exception]
       end


### PR DESCRIPTION
https://github.com/rocketjob/semantic_logger/issues/57