### PR TITLE
fixes #69

### DIFF
--- a/lib/semantic_logger/appender/sentry.rb
+++ b/lib/semantic_logger/appender/sentry.rb
@@ -48,13 +48,12 @@ class SemanticLogger::Appender::Sentry < SemanticLogger::Subscriber
       context.delete(:exception)
       Raven.capture_exception(log.exception, context)
     else
-      message             = {
-        error_class:   context.delete(:name),
-        error_message: context.delete(:message),
+      attrs             = {
+        level:         context.delete(:level),
         extra:         context
       }
-      message[:backtrace] = log.backtrace if log.backtrace
-      Raven.capture_message(message[:error_message], message)
+      attrs[:extra][:backtrace] = log.backtrace if log.backtrace
+      Raven.capture_message(context[:message], attrs)
     end
     true
   end

--- a/test/appender/sentry_test.rb
+++ b/test/appender/sentry_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-# Unit Test for SemanticLogger::Appender::Bugsnag
+# Unit Test for SemanticLogger::Appender::Sentry
 module Appender
   class SentryTest < Minitest::Test
     describe SemanticLogger::Appender::Sentry do
@@ -16,16 +16,16 @@ module Appender
           Raven.stub(:capture_message, -> msg, h { error_message = msg; hash = h }) do
             @appender.send(level, @message)
           end
-          assert_equal @message, hash[:error_message]
-          assert_equal 'SemanticLogger::Appender::Sentry', hash[:error_class]
+          assert_equal @message, error_message
+          assert_equal 'SemanticLogger::Appender::Sentry', hash[:extra][:name]
 
           if [:error, :fatal].include?(level)
-            assert hash.has_key?(:backtrace)
+            assert hash[:extra].has_key?(:backtrace)
           else
-            refute hash.has_key?(:backtrace)
+            refute hash[:extra].has_key?(:backtrace)
           end
           assert_equal true, hash.has_key?(:extra)
-          assert_equal level, hash[:extra][:level]
+          assert_equal level, hash[:level]
         end
 
         it "sends #{level} exceptions" do


### PR DESCRIPTION
* Raven changed `capture_message` params / format
* This sends the params per https://docs.sentry.io/clients/ruby/usage/