### PR TITLE
Support passing all Elasticsearch::Client args

### DIFF
--- a/lib/semantic_logger/appender/elasticsearch.rb
+++ b/lib/semantic_logger/appender/elasticsearch.rb
@@ -64,18 +64,24 @@ class SemanticLogger::Appender::Elasticsearch < SemanticLogger::Subscriber
                  filter: nil,
                  application: nil,
                  host: nil,
+                 **args,
                  &block)
 
-    @url   = url
-    @index = index
-    @type  = type
+    @url                = url
+    @index              = index
+    @type               = type
+    @elasticsearch_args = args[:elasticsearch]
 
     super(level: level, formatter: formatter, filter: filter, application: application, host: host, &block)
     reopen
   end
 
   def reopen
-    @client = Elasticsearch::Client.new(url: url, logger: logger)
+    if @elasticsearch_args
+      @client = Elasticsearch::Client.new(@elasticsearch_args.merge!(logger: logger))
+    else
+      @client = Elasticsearch::Client.new(url: url, logger: logger)
+    end
   end
 
   # Log to the index for today

--- a/test/appender/elasticsearch_test.rb
+++ b/test/appender/elasticsearch_test.rb
@@ -4,121 +4,245 @@ require_relative '../test_helper'
 module Appender
   class ElasticsearchTest < Minitest::Test
     describe SemanticLogger::Appender::Elasticsearch do
-      let :appender do
-        if ENV['ELASTICSEARCH']
-          SemanticLogger::Appender::Elasticsearch.new(url: 'http://localhost:9200')
-        else
-          Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+      describe 'providing a url' do
+        let :appender do
+          if ENV['ELASTICSEARCH']
             SemanticLogger::Appender::Elasticsearch.new(url: 'http://localhost:9200')
-          end
-        end
-      end
-
-      let :log_message do
-        'AppenderElasticsearchTest log message'
-      end
-
-      let :log do
-        log         = SemanticLogger::Log.new('User', :info)
-        log.message = log_message
-        log
-      end
-
-      let :exception do
-        exc = nil
-        begin
-          Uh oh
-        rescue Exception => e
-          exc = e
-        end
-        exc
-      end
-
-      after do
-        appender.close
-      end
-
-      describe 'synchronous' do
-        it 'logs to daily indexes' do
-          bulk_index = nil
-          appender.stub(:write_to_elasticsearch, -> messages { bulk_index = messages.first }) do
-            appender.info log_message
-          end
-          index = bulk_index['index']['_index']
-          assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
-        end
-
-        it 'logs message' do
-          request = stub_client { appender.log(log) }
-
-          assert hash = request[:body][1]
-          assert_equal log_message, hash[:message]
-        end
-
-        it 'logs level' do
-          request = stub_client { appender.log(log) }
-
-          assert hash = request[:body][1]
-          assert_equal :info, hash[:level]
-        end
-
-        it 'logs exception' do
-          log.exception = exception
-          request       = stub_client { appender.log(log) }
-
-          assert hash = request[:body][1]
-          assert exception = hash[:exception]
-          assert_equal 'NameError', exception[:name]
-          assert_match 'undefined local variable or method', exception[:message]
-          assert exception[:stack_trace].first.include?(__FILE__), exception
-        end
-
-        it 'logs payload' do
-          h           = {key1: 1, key2: 'a'}
-          log.payload = h
-          request     = stub_client { appender.log(log) }
-
-          assert hash = request[:body][1]
-          refute hash[:stack_trace]
-          assert_equal h, hash[:payload], hash
-        end
-      end
-
-      describe 'async batch' do
-        it 'logs message' do
-          request = stub_client { appender.batch([log]) }
-
-          assert hash = request[:body][1]
-          assert_equal log_message, hash[:message]
-          assert_equal :info, hash[:level]
-        end
-
-        let :logs do
-          3.times.collect do |i|
-            l         = log.dup
-            l.message = "hello world#{i+1}"
-            l
+          else
+            Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+              SemanticLogger::Appender::Elasticsearch.new(url: 'http://localhost:9200')
+            end
           end
         end
 
-        it 'logs multiple messages' do
-          request = stub_client { appender.batch(logs) }
+        let :log_message do
+          'AppenderElasticsearchTest log message'
+        end
 
-          assert body = request[:body]
-          assert_equal 4, body.size, body
-          index = body[0]['index']['_index']
-          assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
+        let :log do
+          log         = SemanticLogger::Log.new('User', :info)
+          log.message = log_message
+          log
+        end
 
-          assert_equal 'hello world1', body[1][:message]
-          assert_equal 'hello world2', body[2][:message]
-          assert_equal 'hello world3', body[3][:message]
+        let :exception do
+          exc = nil
+          begin
+            Uh oh
+          rescue Exception => e
+            exc = e
+          end
+          exc
+        end
+
+        after do
+          appender.close
+        end
+
+        describe 'synchronous' do
+          it 'logs to daily indexes' do
+            bulk_index = nil
+            appender.stub(:write_to_elasticsearch, ->(messages) { bulk_index = messages.first }) do
+              appender.info log_message
+            end
+            index = bulk_index['index']['_index']
+            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
+          end
+
+          it 'logs message' do
+            request = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert_equal log_message, hash[:message]
+          end
+
+          it 'logs level' do
+            request = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert_equal :info, hash[:level]
+          end
+
+          it 'logs exception' do
+            log.exception = exception
+            request       = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert exception = hash[:exception]
+            assert_equal 'NameError', exception[:name]
+            assert_match 'undefined local variable or method', exception[:message]
+            assert exception[:stack_trace].first.include?(__FILE__), exception
+          end
+
+          it 'logs payload' do
+            h           = { key1: 1, key2: 'a' }
+            log.payload = h
+            request     = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            refute hash[:stack_trace]
+            assert_equal h, hash[:payload], hash
+          end
+        end
+
+        describe 'async batch' do
+          it 'logs message' do
+            request = stub_client { appender.batch([log]) }
+
+            assert hash = request[:body][1]
+            assert_equal log_message, hash[:message]
+            assert_equal :info, hash[:level]
+          end
+
+          let :logs do
+            Array.new(3) do |i|
+              l         = log.dup
+              l.message = "hello world#{i + 1}"
+              l
+            end
+          end
+
+          it 'logs multiple messages' do
+            request = stub_client { appender.batch(logs) }
+
+            assert body = request[:body]
+            assert_equal 4, body.size, body
+            index = body[0]['index']['_index']
+            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
+
+            assert_equal 'hello world1', body[1][:message]
+            assert_equal 'hello world2', body[2][:message]
+            assert_equal 'hello world3', body[3][:message]
+          end
+        end
+
+        def stub_client(&block)
+          request = nil
+          appender.client.stub(:bulk, ->(r) { request = r; { 'status' => 201 } }, &block)
+          request
         end
       end
 
-      def stub_client(&block)
-        request = nil
-        appender.client.stub(:bulk, -> r { request = r; {"status" => 201} }, &block)
-        request
+      describe 'elasticsearch args' do
+        let :appender do
+          Elasticsearch::Transport::Client.stub_any_instance(:bulk, true) do
+            SemanticLogger::Appender::Elasticsearch.new(
+              elasticsearch: {
+                hosts: [{
+                  host: 'localhost',
+                  port: 9200
+                }]
+              }
+            )
+          end
+        end
+
+        let :log_message do
+          'AppenderElasticsearchTest log message'
+        end
+
+        let :log do
+          log         = SemanticLogger::Log.new('User', :info)
+          log.message = log_message
+          log
+        end
+
+        let :exception do
+          exc = nil
+          begin
+            Uh oh
+          rescue Exception => e
+            exc = e
+          end
+          exc
+        end
+
+        after do
+          appender.close
+        end
+
+        describe 'synchronous' do
+          it 'logs to daily indexes' do
+            bulk_index = nil
+            appender.stub(:write_to_elasticsearch, ->(messages) { bulk_index = messages.first }) do
+              appender.info log_message
+            end
+            index = bulk_index['index']['_index']
+            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
+          end
+
+          it 'logs message' do
+            request = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert_equal log_message, hash[:message]
+          end
+
+          it 'logs level' do
+            request = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert_equal :info, hash[:level]
+          end
+
+          it 'logs exception' do
+            log.exception = exception
+            request       = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            assert exception = hash[:exception]
+            assert_equal 'NameError', exception[:name]
+            assert_match 'undefined local variable or method', exception[:message]
+            assert exception[:stack_trace].first.include?(__FILE__), exception
+          end
+
+          it 'logs payload' do
+            h           = { key1: 1, key2: 'a' }
+            log.payload = h
+            request     = stub_client { appender.log(log) }
+
+            assert hash = request[:body][1]
+            refute hash[:stack_trace]
+            assert_equal h, hash[:payload], hash
+          end
+        end
+
+        describe 'async batch' do
+          it 'logs message' do
+            request = stub_client { appender.batch([log]) }
+
+            assert hash = request[:body][1]
+            assert_equal log_message, hash[:message]
+            assert_equal :info, hash[:level]
+          end
+
+          let :logs do
+            Array.new(3) do |i|
+              l         = log.dup
+              l.message = "hello world#{i + 1}"
+              l
+            end
+          end
+
+          it 'logs multiple messages' do
+            request = stub_client { appender.batch(logs) }
+
+            assert body = request[:body]
+            assert_equal 4, body.size, body
+            index = body[0]['index']['_index']
+            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
+
+            assert_equal 'hello world1', body[1][:message]
+            assert_equal 'hello world2', body[2][:message]
+            assert_equal 'hello world3', body[3][:message]
+          end
+        end
+
+        def stub_client(&block)
+          request = nil
+          appender.client.stub(:bulk, ->(r) { request = r; { 'status' => 201 } }, &block)
+          request
+        end
       end
     end
   end


### PR DESCRIPTION
In some cases, passing the url only is insufficient. This adds the ability to pass the full range of arguments directly into the Elasticsearch Client in a backwards compatible way.

For tests, I just duplicated the tests and nested them accordingly to ensure there were no breaking changes.

Please see: https://github.com/elastic/elasticsearch-ruby/blob/master/elasticsearch-transport/lib/elasticsearch/transport/client.rb#L34-L84