### PR TITLE
Add push and pop for named tags

### DIFF
--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -370,12 +370,11 @@ module SemanticLogger
     return yield if hash.nil? || hash.empty?
     raise(ArgumentError, '#named_tagged only accepts named parameters (Hash)') unless hash.is_a?(Hash)
 
-    t = Thread.current[:semantic_logger_named_tags] ||= []
     begin
-      t << hash
+      push_named_tags(hash)
       yield
     ensure
-      t.pop
+      pop_named_tags
     end
   end
 
@@ -390,6 +389,16 @@ module SemanticLogger
     else
       {}
     end
+  end
+
+  def self.push_named_tags(hash)
+    (Thread.current[:semantic_logger_named_tags] ||= []) << hash
+    hash
+  end
+
+  def self.pop_named_tags(quantity=1)
+    t = Thread.current[:semantic_logger_named_tags]
+    t.pop(quantity) unless t.nil?
   end
 
   # Silence noisy log levels by changing the default_level within the block


### PR DESCRIPTION
I have a use case where I'd like to add a log tag but don't have a block to operate on, so I've added `push_named_tags` and `pop_named_tags` to mirror the methods available for regular tags.

cc @smudge