### PR TITLE
Sentry appender can now define user context and tags context

### DIFF
--- a/lib/semantic_logger/appender/sentry.rb
+++ b/lib/semantic_logger/appender/sentry.rb
@@ -49,6 +49,8 @@ class SemanticLogger::Appender::Sentry < SemanticLogger::Subscriber
     context = formatter.call(log, self)
     attrs                     = {
       level: context.delete(:level),
+      user: context.delete(:user),
+      tags: context.delete(:tags),
       extra: context
     }
     if log.exception


### PR DESCRIPTION
If the formatter privides a user entry or tags entry, it will be now passed next to the 'extra' context to sentry.