### PR TITLE
Fix Elasticsearch bulk bugs

### DIFF
--- a/lib/semantic_logger/appender/elasticsearch.rb
+++ b/lib/semantic_logger/appender/elasticsearch.rb
@@ -151,14 +151,8 @@ class SemanticLogger::Appender::Elasticsearch < SemanticLogger::Subscriber
 
   def batch(logs)
     messages = []
-    day      = nil
     logs.each do |log|
-      # Only write the bulk index once per day per batch. Supports mixed dates in a batch.
-      if log.time.day != day
-        messages << bulk_index(log)
-        day = log.time.day
-      end
-      messages << formatter.call(log, self)
+      messages << bulk_index(log) << formatter.call(log, self)
     end
 
     write_to_elasticsearch(messages)

--- a/test/appender/elasticsearch_test.rb
+++ b/test/appender/elasticsearch_test.rb
@@ -106,13 +106,15 @@ module Appender
             request = stub_client { appender.batch(logs) }
 
             assert body = request[:body]
-            assert_equal 4, body.size, body
-            index = body[0]['index']['_index']
-            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
-
+            assert_equal 6, body.size, body
+            
+            index = "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}"
+            assert_equal index,          body[0]['index']['_index']
             assert_equal 'hello world1', body[1][:message]
-            assert_equal 'hello world2', body[2][:message]
-            assert_equal 'hello world3', body[3][:message]
+            assert_equal index,          body[2]['index']['_index']
+            assert_equal 'hello world2', body[3][:message]
+            assert_equal index,          body[4]['index']['_index']
+            assert_equal 'hello world3', body[5][:message]
           end
         end
 
@@ -223,13 +225,15 @@ module Appender
             request = stub_client { appender.batch(logs) }
 
             assert body = request[:body]
-            assert_equal 4, body.size, body
-            index = body[0]['index']['_index']
-            assert_equal "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}", index
-
+            assert_equal 6, body.size, body
+            
+            index = "semantic_logger-#{Time.now.strftime('%Y.%m.%d')}"
+            assert_equal index,          body[0]['index']['_index']
             assert_equal 'hello world1', body[1][:message]
-            assert_equal 'hello world2', body[2][:message]
-            assert_equal 'hello world3', body[3][:message]
+            assert_equal index,          body[2]['index']['_index']
+            assert_equal 'hello world2', body[3][:message]
+            assert_equal index,          body[4]['index']['_index']
+            assert_equal 'hello world3', body[5][:message]
           end
         end
 


### PR DESCRIPTION
Elasticsearch change the bulk API (At least after version 6.0. Not sure on 5.x) so that we can't omit the index name even if it is the same as the previous one. Otherwise the bulk operation will always fail.