### PR TITLE
Fix SemanticLogger.on_log

### DIFF
--- a/lib/semantic_logger/semantic_logger.rb
+++ b/lib/semantic_logger/semantic_logger.rb
@@ -223,7 +223,7 @@ module SemanticLogger
   # * This callback is called within the thread of the application making the logging call.
   # * If these callbacks are slow they will slow down the application.
   def self.on_log(object = nil, &block)
-    Processor.instance.on_log(object, &block)
+    Processor.instance.appender.on_log(object, &block)
   end
 
   # Add signal handlers for Semantic Logger

--- a/test/semantic_logger_test.rb
+++ b/test/semantic_logger_test.rb
@@ -271,6 +271,33 @@ class SemanticLoggerTest < Minitest::Test
           assert_equal 'hello world', log.message
         end
       end
+
+      describe '.on_log' do
+        before do
+          SemanticLogger.default_level = :info
+        end
+
+        after do
+          SemanticLogger::Processor.instance.appender.log_subscribers = nil
+        end
+
+        it 'registers a log listener' do
+          SemanticLogger.on_log do |log|
+            log.set_context(:custom_info, 'test')
+          end
+
+          assert_equal :info, SemanticLogger.default_level
+          assert_equal :info, logger.level
+          logger.silence(:debug) do
+            logger.debug('hello world')
+          end
+
+          assert log = log_message
+          assert_equal :debug, log.level
+          assert_equal 'hello world', log.message
+          assert_equal 'test', log.context[:custom_info]
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
As described in #97, trying to use `SemanticLogger.on_log` produces the following error:

```
/usr/local/bundle/gems/semantic_logger-4.2.0/lib/semantic_logger/semantic_logger.rb:226:in `on_log': undefined method `on_log' for #<SemanticLogger::Appender::Async:0x00000000033fb328> (NoMethodError)
```
