### PR TITLE
Fix typo for syslog exception messages (on LoadError)

### DIFF
--- a/lib/semantic_logger/formatters/syslog.rb
+++ b/lib/semantic_logger/formatters/syslog.rb
@@ -1,7 +1,7 @@
 begin
   require 'syslog_protocol'
 rescue LoadError
-  raise 'Gem syslog_protocol is required for remote logging using the Syslog protol. Please add the gem "syslog_protocol" to your Gemfile.'
+  raise 'Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.'
 end
 
 module SemanticLogger

--- a/lib/semantic_logger/formatters/syslog_cee.rb
+++ b/lib/semantic_logger/formatters/syslog_cee.rb
@@ -1,7 +1,7 @@
 begin
   require 'syslog_protocol'
 rescue LoadError
-  raise 'Gem syslog_protocol is required for remote logging using the Syslog protol. Please add the gem "syslog_protocol" to your Gemfile.'
+  raise 'Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.'
 end
 
 module SemanticLogger


### PR DESCRIPTION
Just small typo fixes for Syslog formatters exception messages.

CI skipped because no need to run it