### PR TITLE
Now syslog appender calls ::Syslog.reopen if it is already opened.

### DIFF
--- a/lib/semantic_logger/appender/syslog.rb
+++ b/lib/semantic_logger/appender/syslog.rb
@@ -164,7 +164,8 @@ module SemanticLogger
       def reopen
         case @protocol
         when :syslog
-          ::Syslog.open(application, options, facility)
+          method = ::Syslog.opened? ? :reopen : :open
+          ::Syslog.send(method, application, options, facility)
         when :tcp
           # Use the local logger for @remote_syslog so errors with the remote logger can be recorded locally.
           @tcp_client_options[:logger] = logger


### PR DESCRIPTION
Fixes https://github.com/rocketjob/rails_semantic_logger/issues/52