### PR TITLE
Splunk/SplunkHTTP Appenders: Fix message metadata format

### DIFF
--- a/lib/semantic_logger/appender/splunk.rb
+++ b/lib/semantic_logger/appender/splunk.rb
@@ -127,7 +127,7 @@ module SemanticLogger
           message: h.delete(:message),
           event:   h
         }
-        message[:source_type] = source_type if source_type
+        message[:sourcetype] = source_type if source_type
         message
       end
     end

--- a/lib/semantic_logger/appender/splunk_http.rb
+++ b/lib/semantic_logger/appender/splunk_http.rb
@@ -96,7 +96,7 @@ module SemanticLogger
           time:   h.delete(:time),
           event:  h
         }
-        message[:source_type] = source_type if source_type
+        message[:sourcetype]  = source_type if source_type
         message[:index]       = index if index
         message.to_json
       end


### PR DESCRIPTION
`source_type` should actually be `sourcetype`

This causes some versions of Splunk and Splunk Cloud to return a 400 Bad
Request with response `{"text":"No data","code":5}` and throw a EOF
Error

See <http://dev.splunk.com/view/event-collector/SP-CAAAE6P#meta> for
more info

### Issue # (if available)


### Description of changes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
