### PR TITLE
Load Fonts by https

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,7 +7,7 @@
   <title>Semantic Logger for Ruby or Rails. Supports Graylog, Bugsnag, MongoDB, Splunk, Syslog, NewRelic.</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
   <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
   <link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
   <link rel="stylesheet" type="text/css" href="stylesheets/pygment_trac.css" media="screen"/>


### PR DESCRIPTION
This allows browsers to accept the fonts from Google by default.

### Issue # (if available)


### Description of changes

Just a tiny change to load fonts as https because my browser is blocking the mixed content. You can see this working as expected at: https://qstearns.github.io/semantic_logger/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
