### PR TITLE
Update Travis Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ rvm:
   - 2.3.7
   - 2.4.4
   - 2.5.1
-  - 2.6.0-preview1
-  - jruby-9.1.17.0
+  - 2.6.0-preview2
+  - jruby-9.2.0.0
 
 matrix:
   allow_failures:
-    - rvm: jruby-9.1.17.0
+    - rvm: jruby-9.2.0.0
 
 bundler_args: --without development
 


### PR DESCRIPTION
### Description of changes

Bumps the Travis Ruby versions for JRuby 9.2.0.0 and Ruby 2.6.0-preview2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
