### PR TITLE
Emphasize risk of backtrace_level in production

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -112,6 +112,8 @@ config.rails_semantic_logger.rendered   = true
 ![Semantic Disabled](images/rails_semantic_false.png)
 
 #### Include the file name and line number in the source code where the message originated
+**Warning:** Either set this to `nil` (to disable it completely) or to a high log level (`:fatal` or `:error`) in your production environment otherwise you risk encountering a memory leak due to the very high number of 
+objects allocated when Ruby backtraces are created. This is best used in development for debugging purposes.
 
 ~~~ruby
 config.semantic_logger.backtrace_level = :info


### PR DESCRIPTION
It's very easy to misread `backtrace_level` as somewhat akin to a log level 
configuration and end up using it in production without understanding how 
much of a performance issue it will cause.

I'm proposing this documentation change as a first step but I really think some 
sort of warning should be printing to the logs if this setting isn't set to a very 
high log level value like `:fatal`/`4` in the production environment.

We had this mistakenly set to `:info` in production and the allocations and memory 
growth/leak were astounding.

![image](https://user-images.githubusercontent.com/65950/43339615-20b8185e-91da-11e8-9ed8-4754bd82db2f.png)
