### PR TITLE
Make #named_tags available on SemanticLogger::Logger

### DIFF
--- a/lib/semantic_logger/base.rb
+++ b/lib/semantic_logger/base.rb
@@ -207,6 +207,10 @@ module SemanticLogger
       SemanticLogger.tags
     end
 
+    def named_tags
+      SemanticLogger.named_tags
+    end
+
     # Returns the list of tags pushed after flattening them out and removing blanks
     #
     # Note:

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -287,10 +287,13 @@ class LoggerTest < Minitest::Test
       it 'also supports named tagging' do
         logger.tagged(level1: 1) do
           assert_equal({level1: 1}, SemanticLogger.named_tags)
+          assert_equal({level1: 1}, logger.named_tags)
           logger.tagged(level2: 2, more: 'data') do
             assert_equal({level1: 1, level2: 2, more: 'data'}, SemanticLogger.named_tags)
+            assert_equal({level1: 1, level2: 2, more: 'data'}, logger.named_tags)
             logger.tagged(level3: 3) do
               assert_equal({level1: 1, level2: 2, more: 'data', level3: 3}, SemanticLogger.named_tags)
+              assert_equal({level1: 1, level2: 2, more: 'data', level3: 3}, logger.named_tags)
             end
           end
         end


### PR DESCRIPTION
### Issue # (if available)

This fixes issue #119

### Description of changes

SemanticLogger::Logging has no access to `#named_tags` found on `SemanticLogger`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
