### PR TITLE
Don't log PID in JRuby

### DIFF
--- a/lib/semantic_logger/log.rb
+++ b/lib/semantic_logger/log.rb
@@ -239,8 +239,9 @@ module SemanticLogger
     def process_info(thread_name_length = 30)
       file, line = file_name_and_line(true)
       file_name  = " #{file}:#{line}" if file
-
-      "#{$$}:#{format("%.#{thread_name_length}s", thread_name)}#{file_name}"
+      # PID has limited value in JRuby, where fork() doesn't work
+      pid = defined?(JRuby) ? '' : "#{$$}:"
+      "#{pid}#{format("%.#{thread_name_length}s", thread_name)}#{file_name}"
     end
 
     CALLER_REGEXP = /^(.*):(\d+).*/

--- a/test/appender/file_test.rb
+++ b/test/appender/file_test.rb
@@ -16,32 +16,33 @@ module Appender
         @hash_str                      = @hash.inspect.sub('{', '\\{').sub('}', '\\}')
         @thread_name                   = Thread.current.name
         @file_name_reg_exp             = RUBY_VERSION.to_f <= 2.0 ? ' (mock|file_test).rb:\d+' : ' file_test.rb:\d+'
+        @pid_regexp                    = defined?(JRuby) ? '' : '\d+:'
       end
 
       describe 'format logs into text form' do
         it 'handle no message or payload' do
           @appender.debug
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File\n/, @io.string)
         end
 
         it 'handle message' do
           @appender.debug 'hello world'
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- hello world\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- hello world\n/, @io.string)
         end
 
         it 'handle message and payload' do
           @appender.debug 'hello world', @hash
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
         end
 
         it 'handle message, payload, and exception' do
           @appender.debug 'hello world', @hash, StandardError.new('StandardError')
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str} -- Exception: StandardError: StandardError\n\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str} -- Exception: StandardError: StandardError\n\n/, @io.string)
         end
 
         it 'logs exception with nil backtrace' do
           @appender.debug StandardError.new('StandardError')
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- Exception: StandardError: StandardError\n\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- Exception: StandardError: StandardError\n\n/, @io.string)
         end
 
         it 'handle nested exception' do
@@ -54,7 +55,7 @@ module Appender
               @appender.debug e2
             end
           end
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name} file_test.rb:\d+\] SemanticLogger::Appender::File -- Exception: StandardError: SecondError\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name} file_test.rb:\d+\] SemanticLogger::Appender::File -- Exception: StandardError: SecondError\n/, @io.string)
           assert_match(/^Cause: StandardError: FirstError\n/, @io.string) if Exception.instance_methods.include?(:cause)
         end
 
@@ -62,7 +63,7 @@ module Appender
           exc = StandardError.new('StandardError')
           exc.set_backtrace([])
           @appender.debug exc
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- Exception: StandardError: StandardError\n\n/, @io.string)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- Exception: StandardError: StandardError\n\n/, @io.string)
         end
 
         it 'ignores metric only messages' do
@@ -82,14 +83,14 @@ module Appender
           it "log #{level} with file_name" do
             SemanticLogger.stub(:backtrace_level_index, 0) do
               @appender.send(level, 'hello world', @hash)
-              assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ \w \[\d+:#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
+              assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ \w \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
             end
           end
 
           it "log #{level} without file_name" do
             SemanticLogger.stub(:backtrace_level_index, 100) do
               @appender.send(level, 'hello world', @hash)
-              assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ \w \[\d+:#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
+              assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ \w \[#{@pid_regexp}#{@thread_name}\] SemanticLogger::Appender::File -- hello world -- #{@hash_str}\n/, @io.string)
             end
           end
         end

--- a/test/appender/wrapper_test.rb
+++ b/test/appender/wrapper_test.rb
@@ -45,27 +45,28 @@ module Appender
         @hash_str          = @hash.inspect.sub('{', '\\{').sub('}', '\\}')
         @thread_name       = Thread.current.name
         @file_name_reg_exp = ' wrapper_test.rb:\d+'
+        @pid_regexp        = defined?(JRuby) ? '' : '\d+:'
       end
 
       describe 'format logs into text form' do
         it 'logs blank data' do
           @appender.debug
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper/, @mock_logger.message)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper/, @mock_logger.message)
         end
 
         it 'logs message' do
           @appender.debug('hello world')
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world/, @mock_logger.message)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world/, @mock_logger.message)
         end
 
         it 'logs message and payload' do
           @appender.debug('hello world', @hash)
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world -- #{@hash_str}/, @mock_logger.message)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world -- #{@hash_str}/, @mock_logger.message)
         end
 
         it 'logs named parameters' do
           @appender.debug(message: 'hello world', payload: @hash)
-          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[\d+:#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world -- #{@hash_str}/, @mock_logger.message)
+          assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ D \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] SemanticLogger::Appender::Wrapper -- hello world -- #{@hash_str}/, @mock_logger.message)
         end
       end
 
@@ -86,7 +87,7 @@ module Appender
             level_char = 'E' if level_char == 'U'
             @logger.send(level.downcase.to_sym, 'hello world', @hash)
             SemanticLogger.flush
-            assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ #{level_char} \[\d+:#{@thread_name}#{@file_name_reg_exp}\] Appender::WrapperTest -- hello world -- #{@hash_str}/, @mock_logger.message)
+            assert_match(/\d+-\d+-\d+ \d+:\d+:\d+.\d+ #{level_char} \[#{@pid_regexp}#{@thread_name}#{@file_name_reg_exp}\] Appender::WrapperTest -- hello world -- #{@hash_str}/, @mock_logger.message)
           end
         end
       end

--- a/test/formatters/color_test.rb
+++ b/test/formatters/color_test.rb
@@ -62,6 +62,10 @@ module SemanticLogger
           formatter
         end
 
+        let(:pid_regexp) do
+          defined?(JRuby) ? '' : "#{$$}:"
+        end
+
         describe 'level' do
           it 'logs single character' do
             assert_equal "#{color}D#{clear}", formatter.level
@@ -131,7 +135,7 @@ module SemanticLogger
 
         describe 'call' do
           it 'returns minimal elements' do
-            assert_equal "#{expected_time} #{color}D#{clear} [#{$$}:#{Thread.current.name}] #{color}ColorTest#{clear}", formatter.call(log, nil)
+            assert_equal "#{expected_time} #{color}D#{clear} [#{pid_regexp}#{Thread.current.name}] #{color}ColorTest#{clear}", formatter.call(log, nil)
           end
 
           it 'retuns all elements' do
@@ -143,7 +147,8 @@ module SemanticLogger
             log.backtrace  = backtrace
             set_exception
             duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? '1' : '1.346'
-            str      = "#{expected_time} #{color}D#{clear} [#{$$}:#{Thread.current.name} default_test.rb:35] [#{color}first#{clear}] [#{color}second#{clear}] [#{color}third#{clear}] {#{color}first: 1#{clear}, #{color}second: 2#{clear}, #{color}third: 3#{clear}} (#{bold}#{duration}ms#{clear}) #{color}ColorTest#{clear} -- Hello World -- #{{first: 1, second: 2, third: 3}.ai(multiline: false)} -- Exception: #{color}RuntimeError: Oh no#{clear}\n"
+
+            str      = "#{expected_time} #{color}D#{clear} [#{pid_regexp}#{Thread.current.name} default_test.rb:35] [#{color}first#{clear}] [#{color}second#{clear}] [#{color}third#{clear}] {#{color}first: 1#{clear}, #{color}second: 2#{clear}, #{color}third: 3#{clear}} (#{bold}#{duration}ms#{clear}) #{color}ColorTest#{clear} -- Hello World -- #{{first: 1, second: 2, third: 3}.ai(multiline: false)} -- Exception: #{color}RuntimeError: Oh no#{clear}\n"
             assert_equal str, formatter.call(log, nil).lines.first
           end
         end

--- a/test/formatters/default_test.rb
+++ b/test/formatters/default_test.rb
@@ -50,6 +50,10 @@ module SemanticLogger
           formatter
         end
 
+        let(:pid_regexp) do
+          defined?(JRuby) ? '' : "#{$$}:"
+        end
+
         describe 'time' do
           it 'logs time' do
             assert_equal expected_time, formatter.time
@@ -70,13 +74,13 @@ module SemanticLogger
 
         describe 'process_info' do
           it 'logs pid and thread name' do
-            assert_equal "[#{$$}:#{Thread.current.name}]", formatter.process_info
+            assert_equal "[#{pid_regexp}#{Thread.current.name}]", formatter.process_info
           end
 
           it 'logs pid, thread name, and file name' do
             set_exception
             log.backtrace = backtrace
-            assert_equal "[#{$$}:#{Thread.current.name} default_test.rb:99]", formatter.process_info
+            assert_equal "[#{pid_regexp}#{Thread.current.name} default_test.rb:99]", formatter.process_info
           end
         end
 
@@ -153,7 +157,7 @@ module SemanticLogger
 
         describe 'call' do
           it 'returns minimal elements' do
-            assert_equal "#{expected_time} D [#{$$}:#{Thread.current.name}] DefaultTest", formatter.call(log, nil)
+            assert_equal "#{expected_time} D [#{pid_regexp}#{Thread.current.name}] DefaultTest", formatter.call(log, nil)
           end
 
           it 'retuns all elements' do
@@ -165,7 +169,7 @@ module SemanticLogger
             log.backtrace  = backtrace
             set_exception
             duration = SemanticLogger::Formatters::Base::PRECISION == 3 ? '1' : '1.346'
-            str      = "#{expected_time} D [#{$$}:#{Thread.current.name} default_test.rb:99] [first] [second] [third] {first: 1, second: 2, third: 3} (#{duration}ms) DefaultTest -- Hello World -- {:first=>1, :second=>2, :third=>3} -- Exception: RuntimeError: Oh no\n"
+            str      = "#{expected_time} D [#{pid_regexp}#{Thread.current.name} default_test.rb:99] [first] [second] [third] {first: 1, second: 2, third: 3} (#{duration}ms) DefaultTest -- Hello World -- {:first=>1, :second=>2, :third=>3} -- Exception: RuntimeError: Oh no\n"
             assert_equal str, formatter.call(log, nil).lines.first
           end
         end


### PR DESCRIPTION
Part of rocketjob/semantic_logger#122

JRuby doesn't implement fork() so the PID is of extremely limited
value -- certainly doesn't need to be on every log line. We could
potentially increase thread_name_length default value on JRuby, since
threads are both more common and named more often.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
