### PR TITLE
Allow precision to be specified for formatters

### DIFF
--- a/lib/semantic_logger/formatters/color.rb
+++ b/lib/semantic_logger/formatters/color.rb
@@ -60,12 +60,13 @@ module SemanticLogger
       #    ColorMaps each of the log levels to a color
       def initialize(ap: {multiline: false},
                      color_map: ColorMap.new,
-                     time_format: TIME_FORMAT,
+                     time_format: nil,
                      log_host: false,
-                     log_application: false)
+                     log_application: false,
+                     precision: PRECISION)
         @ai_options = ap
         @color_map  = color_map.is_a?(ColorMap) ? color_map : ColorMap.new(color_map)
-        super(time_format: time_format, log_host: log_host, log_application: log_application)
+        super(time_format: time_format, log_host: log_host, log_application: log_application, precision: precision)
       end
 
       def level

--- a/lib/semantic_logger/formatters/json.rb
+++ b/lib/semantic_logger/formatters/json.rb
@@ -3,8 +3,10 @@ module SemanticLogger
   module Formatters
     class Json < Raw
       # Default JSON time format is ISO8601
-      def initialize(time_format: :iso_8601, log_host: true, log_application: true, time_key: :timestamp)
-        super(time_format: time_format, log_host: log_host, log_application: log_application, time_key: time_key)
+      def initialize(time_format: :iso_8601, log_host: true, log_application: true, time_key: :timestamp,
+                     precision: PRECISION)
+        super(time_format: time_format, log_host: log_host, log_application: log_application, time_key: time_key,
+              precision: precision)
       end
 
       # Returns log messages in JSON format

--- a/lib/semantic_logger/formatters/raw.rb
+++ b/lib/semantic_logger/formatters/raw.rb
@@ -6,9 +6,9 @@ module SemanticLogger
       attr_accessor :hash, :log, :logger, :time_key
 
       # By default Raw formatter does not reformat the time
-      def initialize(time_format: :none, log_host: true, log_application: true, time_key: :time)
+      def initialize(time_format: :none, log_host: true, log_application: true, time_key: :time, precision: PRECISION)
         @time_key = time_key
-        super(time_format: time_format, log_host: log_host, log_application: log_application)
+        super(time_format: time_format, log_host: log_host, log_application: log_application, precision: precision)
       end
 
       # Host name

--- a/lib/semantic_logger/formatters/signalfx.rb
+++ b/lib/semantic_logger/formatters/signalfx.rb
@@ -10,7 +10,8 @@ module SemanticLogger
                      log_application: true,
                      gauge_name: 'Application.average',
                      counter_name: 'Application.counter',
-                     environment: true)
+                     environment: true,
+                     precision: PRECISION)
 
         @token        = token
         @dimensions   = dimensions.map(&:to_sym) if dimensions
@@ -23,7 +24,7 @@ module SemanticLogger
           @environment = environment
         end
 
-        super(time_format: :ms, log_host: log_host, log_application: log_application)
+        super(time_format: :ms, log_host: log_host, log_application: log_application, precision: precision)
       end
 
       # Create SignalFx friendly metric.

--- a/lib/semantic_logger/log.rb
+++ b/lib/semantic_logger/log.rb
@@ -279,7 +279,7 @@ module SemanticLogger
 
     # DEPRECATED
     def formatted_time
-      time.strftime(Formatters::Base::TIME_FORMAT)
+      time.strftime(Formatters::Base.build_time_format)
     end
 
     DeprecatedLogger = Struct.new(:host, :application)

--- a/test/formatters/default_test.rb
+++ b/test/formatters/default_test.rb
@@ -60,6 +60,27 @@ module SemanticLogger
             formatter.call(log, nil)
             assert_equal '08:32:05', formatter.time
           end
+
+          it 'supports time_format of iso_8601' do
+            formatter = SemanticLogger::Formatters::Default.new(time_format: :iso_8601)
+            formatter.call(log, nil)
+            assert_equal '2017-01-14T08:32:05.375276Z', formatter.time
+          end
+
+          describe 'precision is specified' do
+            it 'follows it for default time format' do
+              formatter = SemanticLogger::Formatters::Default.new(precision: 2)
+              formatter.call(log, nil)
+              assert_equal '2017-01-14 08:32:05.37', formatter.time
+            end
+
+            it 'follows it for iso_8601' do
+              formatter = SemanticLogger::Formatters::Default.new(precision: 2,
+                                                                  time_format: :iso_8601)
+              formatter.call(log, nil)
+              assert_equal '2017-01-14T08:32:05.37Z', formatter.time
+            end
+          end
         end
 
         describe 'level' do


### PR DESCRIPTION
Part of rocketjob/semantic_logger#122

There are some log parsing tools that aren't happy parsing microsecond
logs, and this makes work-around easier when you can't modify them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
