### PR TITLE
Test against Ruby 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ rvm:
 - 2.3.8
 - 2.4.5
 - 2.5.3
-- 2.6.0-preview2
+- 2.6.0
+- ruby-head
 - jruby-9.2.3.0
 
 matrix:
   allow_failures:
-  - rvm: 2.6.0-preview2
+  - rvm: ruby-head
   - rvm: jruby-9.2.3.0
 
 jdk:


### PR DESCRIPTION
### Description of changes
This pull request updates the Travis configuration to test against Ruby 2.6.0. Now that Ruby 2.6.0 is in a stable release, we should test against it. I also added `ruby-head` to the matrix as an allowed failure. This should help identify issues ahead of time. If you would like me to remove it, just let me know.

P.S. We just upgraded to Ruby 2.6.0 and are having a few difficulties that appear to be related to semantic logger. I wanted to push this through first before I opened an issue.