### PR TITLE
Add RabbitMQ appender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.lock
 *.log
 /docs/_site
 .rakeTasks
+/tags

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'rake'
 
 # [optional] Bugsnag appender
 gem 'bugsnag'
+# [optional] Rabbitmq appender
+gem 'bunny'
 # [optional] Elasticsearch appender
 gem 'elasticsearch'
 # [optional] Graylog appender

--- a/lib/semantic_logger/appender.rb
+++ b/lib/semantic_logger/appender.rb
@@ -14,6 +14,7 @@ module SemanticLogger
     autoload :Http,              'semantic_logger/appender/http'
     autoload :MongoDB,           'semantic_logger/appender/mongodb'
     autoload :NewRelic,          'semantic_logger/appender/new_relic'
+    autoload :Rabbitmq,          'semantic_logger/appender/rabbitmq'
     autoload :Splunk,            'semantic_logger/appender/splunk'
     autoload :SplunkHttp,        'semantic_logger/appender/splunk_http'
     autoload :Syslog,            'semantic_logger/appender/syslog'
@@ -56,6 +57,8 @@ module SemanticLogger
       elsif async == true
         proxy_options[:appender] = appender
         Appender::Async.new(proxy_options)
+
+
       else
         appender
       end

--- a/lib/semantic_logger/appender/rabbitmq.rb
+++ b/lib/semantic_logger/appender/rabbitmq.rb
@@ -28,11 +28,59 @@ end
 module SemanticLogger
   module Appender
     class Rabbitmq < SemanticLogger::Subscriber
-      # TODO: doc
+      # Create RabbitMQ appender using Bunny gem
       #
-      def initialize(queue_name: 'semantic_logger', rabbitmq_host: nil, metrics: true, **args, &block)
-        @queue_name = queue_name
-        @rabbitmq_args = args.merge(host: rabbitmq_host)
+      # Parameters:
+      #
+      #   queue_name: [String]
+      #     Name of RabbitMQ queue where to stream logs to.
+      #     This will be a queue bound to AMQP Default exchange
+      #     Default: semantic_logger
+      #
+      #   level: [:trace | :debug | :info | :warn | :error | :fatal]
+      #     Override the log level for this appender.
+      #     Default: SemanticLogger.default_level
+      #
+      #   formatter: [Object|Proc|Symbol|Hash]
+      #     An instance of a class that implements #call, or a Proc to be used to format
+      #     the output from this appender
+      #     Default: :json (See: #call)
+      #
+      #   filter: [Regexp|Proc]
+      #     RegExp: Only include log messages where the class name matches the supplied.
+      #     regular expression. All other messages will be ignored.
+      #     Proc: Only include log messages where the supplied Proc returns true
+      #           The Proc must return true or false.
+      #
+      #   host: [String]
+      #     Name of this host to appear in log messages.
+      #     Default: SemanticLogger.host
+      #
+      #   application: [String]
+      #     Name of this application to appear in log messages.
+      #     Default: SemanticLogger.application
+      #
+      # RabbitMQ Parameters:
+      #
+      #   rabbitmq_host: [String]
+      #     Host for AMQP connection. in Bunny this is called :host but here it has 
+      #     been remapped to avoid conflicting with SemanticLogger's :host param.
+      #     Default: localhost
+      #
+      #   username: [String]
+      #     Username for AMQP connection
+      #     Default: nil
+      #
+      #   password: [String]
+      #     Password for AMQP connection
+      #     Default: nil
+      #
+      #   more parameters supported by Bunny: http://rubybunny.info/articles/connecting.html
+      def initialize(queue_name: 'semantic_logger', rabbitmq_host: nil, metrics: false, **args, &block)
+        @queue_name             = queue_name
+        @rabbitmq_args          = args.dup
+        @rabbitmq_args[:host]   = rabbitmq_host
+        @rabbitmq_args[:logger] = logger
 
         super(level: level, formatter: formatter, filter: filter, application: application, host: host, metrics: metrics, &block)
         reopen

--- a/lib/semantic_logger/appender/rabbitmq.rb
+++ b/lib/semantic_logger/appender/rabbitmq.rb
@@ -1,0 +1,73 @@
+begin
+  require 'bunny'
+rescue LoadError
+  raise 'Gem bunny is required for logging to RabbitMQ. Please add the gem "bunny" to your Gemfile.'
+end
+
+# Forward all log messages to RabbitMQ.
+#
+# Example:
+#
+#   SemanticLogger.add_appender(
+#     appender: :rabbitmq,
+#
+#     # Name of the queue in RabbitMQ where to publish the logs. This queue will be bound to "amqp.direct" exchange.
+#     queue: 'semantic_logger',
+#
+#     # This host will be used for RabbitMQ connection. 
+#     # NOTE this is different than :host option which is used by the logger directly.
+#     rabbitmq_host: '127.0.0.1',
+#
+#     # RabbitMQ credentials
+#     username: 'my-username',
+#     password: 'my-secrect-pass',
+#
+#     # All other options accepted by Bunny.new call
+#     vhost: 'production',
+#   )
+module SemanticLogger
+  module Appender
+    class Rabbitmq < SemanticLogger::Subscriber
+      # TODO: doc
+      #
+      def initialize(queue_name: 'semantic_logger', rabbitmq_host: nil, metrics: true, **args, &block)
+        @queue_name = queue_name
+        @rabbitmq_args = args.merge(host: rabbitmq_host)
+
+        super(level: level, formatter: formatter, filter: filter, application: application, host: host, metrics: metrics, &block)
+        reopen
+      end
+
+      def reopen
+        @connection = Bunny.new(@rabbitmq_args)
+        @connection.start
+        @channel = @connection.create_channel
+      end
+
+      def close
+        @channel&.close
+        @channel = nil
+        @connection&.close
+        @connection = nil
+      end
+
+      def log(log)
+        queue.publish(formatter.call(log, self))
+      end
+
+      def flush
+        # NOOP
+      end
+
+      # Use JSON Formatter by default.
+      def default_formatter
+        SemanticLogger::Formatters::Json.new
+      end
+
+
+      def queue
+        @queue ||= @channel.queue(@queue_name)
+      end
+    end
+  end
+end

--- a/lib/semantic_logger/appender/rabbitmq.rb
+++ b/lib/semantic_logger/appender/rabbitmq.rb
@@ -112,7 +112,6 @@ module SemanticLogger
         SemanticLogger::Formatters::Json.new
       end
 
-
       def queue
         @queue ||= @channel.queue(@queue_name)
       end

--- a/test/appender/fake_bunny.rb
+++ b/test/appender/fake_bunny.rb
@@ -1,0 +1,39 @@
+# Fake class for Bunny (RabbitMQ client)
+class FakeBunny
+  class Channel
+    def initialize(conn)
+      @conn = conn
+    end
+
+    def queue(name)
+      Queue.new(name, @conn)
+    end
+
+    def close; end
+  end
+
+  class Queue
+    def initialize(name, conn)
+      @name = name
+      @conn = conn
+    end
+
+    def publish(message)
+      @conn.published << { message: message, queue: @name }
+    end
+  end
+
+  attr_accessor :published, :args
+
+  def initialize(args)
+    @args = args
+    @published = []
+  end
+
+  def start; end
+  def close; end
+
+  def create_channel
+    Channel.new(self)
+  end
+end

--- a/test/appender/mongodb_test.rb
+++ b/test/appender/mongodb_test.rb
@@ -4,25 +4,24 @@ require_relative '../test_helper'
 module Appender
   class MongoDBTest < Minitest::Test
     describe SemanticLogger::Appender::MongoDB do
-      # before do
-      #   @appender           = SemanticLogger::Appender::MongoDB.new(
-      #     uri:             'mongodb://127.0.0.1:27017/test',
-      #     collection_size: 10 * 1024 ** 2, # 10MB
-      #     host:        'test',
-      #     application: 'test_application',
-      #     level:       :trace
-      #   )
-      #   @hash               = {tracking_number: 12_345, session_id: 'HSSKLEU@JDK767'}
-      #   Thread.current.name = 'thread'
-      # end
+      before do
+        @appender           = SemanticLogger::Appender::MongoDB.new(
+          uri:             'mongodb://127.0.0.1:27017/test',
+          collection_size: 10 * 1024 ** 2, # 10MB
+          host:        'test',
+          application: 'test_application',
+          level:       :trace
+        )
+        @hash               = {tracking_number: 12_345, session_id: 'HSSKLEU@JDK767'}
+        Thread.current.name = 'thread'
+      end
 
-      # after do
-      #   @appender&.purge_all
-      # end
+      after do
+        @appender&.purge_all
+      end
 
       describe 'format logs into documents' do
         it 'handle no arguments' do
-          skip
           @appender.debug
           document = @appender.collection.find.first
           assert_equal :debug, document['level']
@@ -36,7 +35,6 @@ module Appender
         end
 
         it 'handle named parameters' do
-          skip
           @appender.debug(payload: @hash)
 
           document = @appender.collection.find.first
@@ -53,7 +51,6 @@ module Appender
         end
 
         it 'handle message and payload' do
-          skip
           @appender.debug('hello world', @hash)
 
           document = @appender.collection.find.first
@@ -70,7 +67,6 @@ module Appender
         end
 
         it 'handle message without payload' do
-          skip
           @appender.debug('hello world')
 
           document = @appender.collection.find.first
@@ -88,7 +84,6 @@ module Appender
       SemanticLogger::LEVELS.each do |level|
         describe "##{level}" do
           it 'logs' do
-            skip
             @appender.send(level, 'hello world -- Calculations', @hash)
             document = @appender.collection.find.first
             assert_equal level, document['level']

--- a/test/appender/mongodb_test.rb
+++ b/test/appender/mongodb_test.rb
@@ -4,24 +4,25 @@ require_relative '../test_helper'
 module Appender
   class MongoDBTest < Minitest::Test
     describe SemanticLogger::Appender::MongoDB do
-      before do
-        @appender           = SemanticLogger::Appender::MongoDB.new(
-          uri:             'mongodb://127.0.0.1:27017/test',
-          collection_size: 10 * 1024 ** 2, # 10MB
-          host:        'test',
-          application: 'test_application',
-          level:       :trace
-        )
-        @hash               = {tracking_number: 12_345, session_id: 'HSSKLEU@JDK767'}
-        Thread.current.name = 'thread'
-      end
+      # before do
+      #   @appender           = SemanticLogger::Appender::MongoDB.new(
+      #     uri:             'mongodb://127.0.0.1:27017/test',
+      #     collection_size: 10 * 1024 ** 2, # 10MB
+      #     host:        'test',
+      #     application: 'test_application',
+      #     level:       :trace
+      #   )
+      #   @hash               = {tracking_number: 12_345, session_id: 'HSSKLEU@JDK767'}
+      #   Thread.current.name = 'thread'
+      # end
 
-      after do
-        @appender&.purge_all
-      end
+      # after do
+      #   @appender&.purge_all
+      # end
 
       describe 'format logs into documents' do
         it 'handle no arguments' do
+          skip
           @appender.debug
           document = @appender.collection.find.first
           assert_equal :debug, document['level']
@@ -35,6 +36,7 @@ module Appender
         end
 
         it 'handle named parameters' do
+          skip
           @appender.debug(payload: @hash)
 
           document = @appender.collection.find.first
@@ -51,6 +53,7 @@ module Appender
         end
 
         it 'handle message and payload' do
+          skip
           @appender.debug('hello world', @hash)
 
           document = @appender.collection.find.first
@@ -67,6 +70,7 @@ module Appender
         end
 
         it 'handle message without payload' do
+          skip
           @appender.debug('hello world')
 
           document = @appender.collection.find.first
@@ -84,6 +88,7 @@ module Appender
       SemanticLogger::LEVELS.each do |level|
         describe "##{level}" do
           it 'logs' do
+            skip
             @appender.send(level, 'hello world -- Calculations', @hash)
             document = @appender.collection.find.first
             assert_equal level, document['level']

--- a/test/appender/rabbitmq_test.rb
+++ b/test/appender/rabbitmq_test.rb
@@ -18,8 +18,10 @@ module Appender
             password: 'the-password'
           )
 
-          expected_bunny_args = [{ host: 'localhost', username: 'the-username', password: 'the-password' }]
-          assert_equal expected_bunny_args, bunny.args
+          bunny_args = bunny.args.first
+          assert_equal 'localhost', bunny_args[:host]
+          assert_equal 'the-username', bunny_args[:username]
+          assert_equal 'the-password', bunny_args[:password]
 
           message  = 'AppenderRabbitmqTest log message'
           @appender.info(message)

--- a/test/appender/rabbitmq_test.rb
+++ b/test/appender/rabbitmq_test.rb
@@ -1,0 +1,38 @@
+require_relative '../test_helper'
+require_relative 'fake_bunny'
+
+module Appender
+  class RabbitmqTest < Minitest::Test
+    describe SemanticLogger::Appender::Rabbitmq do
+      after do
+        @appender&.close
+      end
+
+      it 'sends log messages in JSON format' do
+        bunny = nil
+        Bunny.stub(:new, ->(*args) { bunny = FakeBunny.new(args) }) do
+          @appender = SemanticLogger::Appender::Rabbitmq.new(
+            queue_name: 'test_queue',
+            rabbitmq_host: 'localhost',
+            username: 'the-username',
+            password: 'the-password'
+          )
+
+          expected_bunny_args = [{ host: 'localhost', username: 'the-username', password: 'the-password' }]
+          assert_equal expected_bunny_args, bunny.args
+
+          message  = 'AppenderRabbitmqTest log message'
+          @appender.info(message)
+          @appender.flush
+
+          assert_equal 'test_queue', bunny.published.first[:queue]
+          h = JSON.parse(bunny.published.first[:message])
+          assert_equal 'info', h['level']
+          assert_equal message, h['message']
+          assert_equal 'SemanticLogger::Appender::Rabbitmq', h['name']
+          assert_equal $$, h['pid']
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there,
Thank you for developing and maintaining such interesting tool!

I would like to adds support for streaming logs to RabbitMQ broker.
I've created and a tested a new appender called `SemanticLogger::Appender::Rabbitmq` and updated the documentation.

Usage:
~~~ruby
SemanticLogger.add_appender(
  appender:      :rabbitmq,
  queue_name:    'semantic_logger', 
  rabbitmq_host: 'localhost',
  username:      'the-username',
  password:      'the-password',
  # rest of options supported by Bunny gem
)
~~~

Please let me know if I am missing anything.

Thank you,

Fabio

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
