### PR TITLE
Fix 'NameError' always raised and logged by Appenders#close

### DIFF
--- a/lib/semantic_logger/appenders.rb
+++ b/lib/semantic_logger/appenders.rb
@@ -43,7 +43,7 @@ module SemanticLogger
           logger.trace "Closing appender: #{appender.name}"
           appender.flush
           appender.close
-          appenders.delete(appender)
+          delete(appender)
         rescue Exception => exc
           logger.error "Failed to close appender: #{appender.inspect}", exc
         end


### PR DESCRIPTION
Fix 'NameError' always raised and logged by Appenders#close, due to wrong access to an unknown variable when deleting an appender

### Issue https://github.com/rocketjob/semantic_logger/issues/133

### Description of changes

- `Appenders#close` has been modified, so that it now correctly removes each appender, without causing a `NameError` exception to be logged out.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
