### PR TITLE
Always re-raise with LoadError

### DIFF
--- a/lib/semantic_logger/appender/bugsnag.rb
+++ b/lib/semantic_logger/appender/bugsnag.rb
@@ -1,7 +1,7 @@
 begin
   require 'bugsnag'
 rescue LoadError
-  raise 'Gem bugsnag is required for logging purposes. Please add the gem "bugsnag" to your Gemfile.'
+  raise LoadError.new('Gem bugsnag is required for logging purposes. Please add the gem "bugsnag" to your Gemfile.')
 end
 
 # Send log messages to Bugsnag

--- a/lib/semantic_logger/appender/elasticsearch.rb
+++ b/lib/semantic_logger/appender/elasticsearch.rb
@@ -1,7 +1,7 @@
 begin
   require 'elasticsearch'
 rescue LoadError
-  raise 'Gem elasticsearch is required for logging to Elasticsearch. Please add the gem "elasticsearch" to your Gemfile.'
+  raise LoadError.new('Gem elasticsearch is required for logging to Elasticsearch. Please add the gem "elasticsearch" to your Gemfile.')
 end
 
 require 'date'

--- a/lib/semantic_logger/appender/graylog.rb
+++ b/lib/semantic_logger/appender/graylog.rb
@@ -2,7 +2,7 @@ require 'uri'
 begin
   require 'gelf'
 rescue LoadError
-  raise 'Gem gelf is required for logging to Graylog. Please add the gem "gelf" to your Gemfile.'
+  raise LoadError.new('Gem gelf is required for logging to Graylog. Please add the gem "gelf" to your Gemfile.')
 end
 
 # Forward log entries to a Graylog server.

--- a/lib/semantic_logger/appender/honeybadger.rb
+++ b/lib/semantic_logger/appender/honeybadger.rb
@@ -1,7 +1,7 @@
 begin
   require 'honeybadger'
 rescue LoadError
-  raise 'Gem honeybadger is required for logging purposes. Please add the gem "honeybadger" to your Gemfile.'
+  raise LoadError.new('Gem honeybadger is required for logging purposes. Please add the gem "honeybadger" to your Gemfile.')
 end
 
 # Send log messages to honeybadger

--- a/lib/semantic_logger/appender/kafka.rb
+++ b/lib/semantic_logger/appender/kafka.rb
@@ -1,7 +1,7 @@
 begin
   require 'kafka'
 rescue LoadError
-  raise 'Gem ruby-kafka is required for logging to Elasticsearch. Please add the gem "ruby-kafka" to your Gemfile.'
+  raise LoadError.new('Gem ruby-kafka is required for logging to Elasticsearch. Please add the gem "ruby-kafka" to your Gemfile.')
 end
 
 require 'date'

--- a/lib/semantic_logger/appender/mongodb.rb
+++ b/lib/semantic_logger/appender/mongodb.rb
@@ -2,7 +2,7 @@ require 'socket'
 begin
   require 'mongo'
 rescue LoadError
-  raise 'Gem mongo is required for logging to MongoDB. Please add the gem "mongo" v2.0 or greater to your Gemfile.'
+  raise LoadError.new('Gem mongo is required for logging to MongoDB. Please add the gem "mongo" v2.0 or greater to your Gemfile.')
 end
 
 module SemanticLogger

--- a/lib/semantic_logger/appender/new_relic.rb
+++ b/lib/semantic_logger/appender/new_relic.rb
@@ -1,7 +1,7 @@
 begin
   require 'newrelic_rpm'
 rescue LoadError
-  raise 'Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.'
+  raise LoadError.new('Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.')
 end
 
 # Send log messages to NewRelic

--- a/lib/semantic_logger/appender/rabbitmq.rb
+++ b/lib/semantic_logger/appender/rabbitmq.rb
@@ -1,7 +1,7 @@
 begin
   require 'bunny'
 rescue LoadError
-  raise 'Gem bunny is required for logging to RabbitMQ. Please add the gem "bunny" to your Gemfile.'
+  raise LoadError.new('Gem bunny is required for logging to RabbitMQ. Please add the gem "bunny" to your Gemfile.')
 end
 
 # Forward all log messages to RabbitMQ.

--- a/lib/semantic_logger/appender/sentry.rb
+++ b/lib/semantic_logger/appender/sentry.rb
@@ -1,7 +1,7 @@
 begin
   require 'sentry-raven'
 rescue LoadError
-  raise 'Gem sentry-raven is required for logging purposes. Please add the gem "sentry-raven" to your Gemfile.'
+  raise LoadError.new('Gem sentry-raven is required for logging purposes. Please add the gem "sentry-raven" to your Gemfile.')
 end
 
 # Send log messages to sentry

--- a/lib/semantic_logger/appender/splunk.rb
+++ b/lib/semantic_logger/appender/splunk.rb
@@ -1,7 +1,7 @@
 begin
   require 'splunk-sdk-ruby'
 rescue LoadError
-  raise 'Gem splunk-sdk-ruby is required for logging to Splunk. Please add the gem "splunk-sdk-ruby" to your Gemfile.'
+  raise LoadError.new('Gem splunk-sdk-ruby is required for logging to Splunk. Please add the gem "splunk-sdk-ruby" to your Gemfile.')
 end
 
 # Splunk log appender.

--- a/lib/semantic_logger/appender/syslog.rb
+++ b/lib/semantic_logger/appender/syslog.rb
@@ -145,7 +145,7 @@ module SemanticLogger
           begin
             require 'syslog_protocol'
           rescue LoadError
-            raise 'Missing gem: syslog_protocol. This gem is required when logging over TCP or UDP. To fix this error: gem install syslog_protocol'
+            raise LoadError.new('Missing gem: syslog_protocol. This gem is required when logging over TCP or UDP. To fix this error: gem install syslog_protocol')
           end
 
           # The net_tcp_client gem is required when logging over TCP.
@@ -153,7 +153,7 @@ module SemanticLogger
             begin
               require 'net/tcp_client'
             rescue LoadError
-              raise 'Missing gem: net_tcp_client. This gem is required when logging over TCP. To fix this error: gem install net_tcp_client'
+              raise LoadError.new('Missing gem: net_tcp_client. This gem is required when logging over TCP. To fix this error: gem install net_tcp_client')
             end
           end
         end

--- a/lib/semantic_logger/appender/tcp.rb
+++ b/lib/semantic_logger/appender/tcp.rb
@@ -1,7 +1,7 @@
 begin
   require 'net/tcp_client'
 rescue LoadError
-  raise 'Gem net_tcp_client is required for logging over TCP. Please add the gem "net_tcp_client" to your Gemfile.'
+  raise LoadError.new('Gem net_tcp_client is required for logging over TCP. Please add the gem "net_tcp_client" to your Gemfile.')
 end
 
 raise 'Net::TCPClient v2.0 or greater is required to log over TCP' unless Net::TCPClient::VERSION.to_f >= 2.0

--- a/lib/semantic_logger/formatters/syslog.rb
+++ b/lib/semantic_logger/formatters/syslog.rb
@@ -1,7 +1,7 @@
 begin
   require 'syslog_protocol'
 rescue LoadError
-  raise 'Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.'
+  raise LoadError.new('Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.')
 end
 
 module SemanticLogger

--- a/lib/semantic_logger/formatters/syslog_cee.rb
+++ b/lib/semantic_logger/formatters/syslog_cee.rb
@@ -1,7 +1,7 @@
 begin
   require 'syslog_protocol'
 rescue LoadError
-  raise 'Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.'
+  raise LoadError.new('Gem syslog_protocol is required for remote logging using the Syslog protocol. Please add the gem "syslog_protocol" to your Gemfile.')
 end
 
 module SemanticLogger

--- a/lib/semantic_logger/metric/new_relic.rb
+++ b/lib/semantic_logger/metric/new_relic.rb
@@ -1,7 +1,7 @@
 begin
   require 'newrelic_rpm'
 rescue LoadError
-  raise 'Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.'
+  raise LoadError.new('Gem newrelic_rpm is required for logging to New Relic. Please add the gem "newrelic_rpm" to your Gemfile.')
 end
 
 # Send Metrics to NewRelic

--- a/lib/semantic_logger/metric/statsd.rb
+++ b/lib/semantic_logger/metric/statsd.rb
@@ -2,7 +2,7 @@ require 'uri'
 begin
   require 'statsd-ruby'
 rescue LoadError
-  raise 'Gem statsd-ruby is required for logging metrics. Please add the gem "statsd-ruby" to your Gemfile.'
+  raise LoadError.new('Gem statsd-ruby is required for logging metrics. Please add the gem "statsd-ruby" to your Gemfile.')
 end
 
 module SemanticLogger


### PR DESCRIPTION
### Issue # (if available)

Fixes #138
Fixes sorbet/sorbet#1820


### Description of changes

It's a best practice to re-raise a LoadError exception when catching a
LoadError exception, so that scripts can attempt to be resilient in the
face of a LoadError. Having to swallow all RuntimeExceptions is the
alternative, and it often makes things more brittle, rather than less.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.