### PR TITLE
[doc] Add DelayedJob to "Replacing Existing loggers"

### DIFF
--- a/docs/rails.md
+++ b/docs/rails.md
@@ -442,5 +442,6 @@ after they have been initialized:
 - Resque
 - Sidekiq
 - Sidetiq
+- DelayedJob
 
 ### [Next: Centralized Logging ==>](centralized_logging.html)


### PR DESCRIPTION

### Issue # (if available)
None

### Description of changes
Replacing existing loggers of DelayedJob is already supported in following PRs.
https://github.com/rocketjob/rails_semantic_logger/pull/56
https://github.com/rocketjob/rails_semantic_logger/pull/65

So, I've added 'DelayedJob' to "Replacing Existing loggers" section.