### PR TITLE
refs #146 restore SemanticLogger::Log.to_h

### DIFF
--- a/lib/semantic_logger/log.rb
+++ b/lib/semantic_logger/log.rb
@@ -281,6 +281,12 @@ module SemanticLogger
       !(payload.nil? || (payload.respond_to?(:empty?) && payload.empty?))
     end
 
+    def to_h(host = SemanticLogger.host, application = SemanticLogger.application, environment = SemanticLogger.environment)
+      logger = Struct.new(:host, :application, :environment)
+                     .new(host, application, environment)
+      SemanticLogger::Formatters::Raw.new.call(self, logger)
+    end
+
     # Lazy initializes the context hash and assigns a key value pair.
     def set_context(key, value)
       (self.context ||= {})[key] = value

--- a/test/measure_test.rb
+++ b/test/measure_test.rb
@@ -127,7 +127,7 @@ class MeasureTest < Minitest::Test
             assert log.backtrace.size.positive?
 
             # Extract file name and line number from backtrace
-            h = SemanticLogger::Formatters::Raw.new.call(log, appender)
+            h = log.to_h
             assert_match /measure_test.rb/, h[:file], h
             assert h[:line].is_a?(Integer)
           end
@@ -208,7 +208,7 @@ class MeasureTest < Minitest::Test
             assert log.backtrace.size.positive?
 
             # Extract file name and line number from backtrace
-            h = SemanticLogger::Formatters::Raw.new.call(log, appender)
+            h = log.to_h
             assert_match /measure_test.rb/, h[:file], h
             assert h[:line].is_a?(Integer)
           end
@@ -290,7 +290,7 @@ class MeasureTest < Minitest::Test
             assert log.backtrace.size.positive?
 
             # Extract file name and line number from backtrace
-            h = SemanticLogger::Formatters::Raw.new.call(log, appender)
+            h = log.to_h
             assert_match /measure_test.rb/, h[:file], h
             assert h[:line].is_a?(Integer)
           end


### PR DESCRIPTION
### Issue # (if available)

#146

### Description of changes

restores SemanticLogger::Log.to_h method

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
