### PR TITLE
Fix SplunkHttp appender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Fix an undefined method error when handling exceptions from on_log.
+- Remove `environment` from the `SplunkHttp` appender message body.
 
 ### Added
 

--- a/lib/semantic_logger/appender/splunk_http.rb
+++ b/lib/semantic_logger/appender/splunk_http.rb
@@ -87,7 +87,7 @@ module SemanticLogger
       # Returns [String] JSON to send to Splunk.
       #
       # For splunk format requirements see:
-      #   http://dev.splunk.com/view/event-collector/SP-CAAAE6P
+      #   https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector
       def call(log, logger)
         h                     = SemanticLogger::Formatters::Raw.new(time_format: :seconds).call(log, logger)
         message               = {
@@ -96,7 +96,6 @@ module SemanticLogger
           time:   h.delete(:time),
           event:  h
         }
-        message[:environment] = logger.environment if logger.environment
         message[:sourcetype]  = source_type if source_type
         message[:index]       = index if index
         message.to_json


### PR DESCRIPTION
`environment` is not a valid root key for the Splunk HTTP Event
Collector. Including it results in a response code of `400` and a JSON
response body of `{"text":"No data","code":5}`.

This PR also updates the URL for the documentation since it has changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
