### PR TITLE
Do not include host field in splunk event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Remove `host` from the `SplunkHttp` appender message body.
+
 ### Added
 
 ## [4.7.1]

--- a/lib/semantic_logger/appender/splunk_http.rb
+++ b/lib/semantic_logger/appender/splunk_http.rb
@@ -90,6 +90,7 @@ module SemanticLogger
       #   https://docs.splunk.com/Documentation/Splunk/latest/Data/FormateventsforHTTPEventCollector
       def call(log, logger)
         h                     = SemanticLogger::Formatters::Raw.new(time_format: :seconds).call(log, logger)
+        h.delete(:host)
         message               = {
           source: logger.application,
           host:   logger.host,

--- a/test/appender/splunk_http_test.rb
+++ b/test/appender/splunk_http_test.rb
@@ -58,6 +58,7 @@ module Appender
           body = decompress_data(request.body)
           message = JSON.parse(body)
           assert event = message["event"], message.ai
+          refute_includes message["event"], "host"
           assert_equal @message, event["message"]
           assert_equal level.to_s, event["level"]
           refute event["stack_trace"]


### PR DESCRIPTION
### Description of changes

This change removes the `host` field from the splunk event. This makes sense because the host is already sent to splunk in the request using the `host` field. This removes duplicate information from splunk and makes it idiomatic. For example:

#### new body

```json
{
  "source": "Semantic Logger",
  "host": "my-hostname",
  "time": 1595506676.082487,
  "event": {
    "application": "Semantic Logger",
    "environment": "test",
    "level": "info",
    "level_index": 2,
    "pid": 90292,
    "thread": "3180",
    "name": "SemanticLogger::Appender::SplunkHttp",
    "message": "AppenderSplunkHttpTest log message",
    "payload": {
      "key1": 1,
      "key2": "a"
    }
  }
}
```

#### old body

```json
{
  "source": "Semantic Logger",
  "host": "my-hostname",
  "time": 1595506779.097824,
  "event": {
    "host": "my-hostname",
    "application": "Semantic Logger",
    "environment": "test",
    "level": "fatal",
    "level_index": 5,
    "pid": 91378,
    "thread": "3180",
    "file": "test/appender/splunk_http_test.rb",
    "line": 56,
    "name": "SemanticLogger::Appender::SplunkHttp",
    "message": "AppenderSplunkHttpTest log message",
    "payload": {
      "key1": 1,
      "key2": "a"
    }
  }
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
