### PR TITLE
Set packet size for syslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Changed
+- Instead of the `.to_s` method we use the `assemble` method of the `SyslogProtocol::Packet` class.
+
 ### Fixed
 
 ### Added

--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -75,7 +75,7 @@ Log to a local Syslog daemon
 SemanticLogger.add_appender(appender: :syslog)
 ~~~
 
-Log to a remote Syslog server using TCP with packet size 2048bytes. By default the size if 1024:
+Log to a remote Syslog server using TCP with packet size 2048 bytes. By default the size is 1024 bytes:
 
 ~~~ruby
 SemanticLogger.add_appender(

--- a/docs/appenders.md
+++ b/docs/appenders.md
@@ -75,12 +75,13 @@ Log to a local Syslog daemon
 SemanticLogger.add_appender(appender: :syslog)
 ~~~
 
-Log to a remote Syslog server using TCP:
+Log to a remote Syslog server using TCP with packet size 2048bytes. By default the size if 1024:
 
 ~~~ruby
 SemanticLogger.add_appender(
   appender: :syslog,
-  url:      'tcp://myloghost:514'
+  url:      'tcp://myloghost:514',
+  max_size: 2048
 )
 ~~~
 

--- a/lib/semantic_logger/appender/syslog.rb
+++ b/lib/semantic_logger/appender/syslog.rb
@@ -31,7 +31,7 @@ require "socket"
 module SemanticLogger
   module Appender
     class Syslog < SemanticLogger::Subscriber
-      attr_reader :remote_syslog, :url, :server, :port, :protocol, :facility, :options, :level_map
+      attr_reader :remote_syslog, :url, :server, :port, :protocol, :facility, :options, :level_map, :max_size
 
       # Create a Syslog appender instance.
       #
@@ -72,6 +72,10 @@ module SemanticLogger
       #   application: [String]
       #     Identity of the program.
       #     Default: SemanticLogger.application
+      #
+      #   max_size: [Integer]
+      #     Set your own packet size.
+      #     Default: 1024 bytes
       #
       #   options: [Integer]
       #     Default: ::Syslog::LOG_PID | ::Syslog::LOG_CONS
@@ -121,6 +125,7 @@ module SemanticLogger
       #     SemanticLogger.add_appender(appender: :syslog, level_map: {warn: ::Syslog::LOG_NOTICE})
       def initialize(url: "syslog://localhost",
                      facility: ::Syslog::LOG_USER,
+                     max_size: 1024,
                      level_map: SemanticLogger::Formatters::Syslog::LevelMap.new,
                      options: ::Syslog::LOG_PID | ::Syslog::LOG_CONS,
                      tcp_client: {},
@@ -129,6 +134,7 @@ module SemanticLogger
 
         @options            = options
         @facility           = facility
+        @max_size           = max_size
         @level_map          = level_map
         @url                = url
         uri                 = URI(@url)
@@ -209,7 +215,7 @@ module SemanticLogger
           # Format is text output without the time
           SemanticLogger::Formatters::Default.new(time_format: nil)
         else
-          SemanticLogger::Formatters::Syslog.new(facility: facility, level_map: level_map)
+          SemanticLogger::Formatters::Syslog.new(facility: facility, level_map: level_map, max_size: max_size)
         end
       end
     end

--- a/lib/semantic_logger/formatters/syslog.rb
+++ b/lib/semantic_logger/formatters/syslog.rb
@@ -7,7 +7,7 @@ end
 module SemanticLogger
   module Formatters
     class Syslog < Default
-      attr_accessor :level_map, :facility
+      attr_accessor :level_map, :facility, :max_size
 
       # Default level map for every log level
       #
@@ -50,9 +50,10 @@ module SemanticLogger
       #   Example:
       #     # Change the warn level to LOG_NOTICE level instead of a the default of LOG_WARNING.
       #     SemanticLogger.add_appender(appender: :syslog, level_map: {warn: ::Syslog::LOG_NOTICE})
-      def initialize(facility: ::Syslog::LOG_USER, level_map: LevelMap.new)
+      def initialize(facility: ::Syslog::LOG_USER, level_map: LevelMap.new, max_size: Integer)
         @facility  = facility
         @level_map = level_map.is_a?(LevelMap) ? level_map : LevelMap.new(level_map)
+        @max_size = max_size
         super()
       end
 
@@ -77,7 +78,7 @@ module SemanticLogger
         packet.content  = message
         packet.time     = log.time
         packet.severity = level_map[log.level]
-        packet.to_s
+        packet.assemble(@max_size)
       end
     end
   end

--- a/lib/semantic_logger/formatters/syslog_cee.rb
+++ b/lib/semantic_logger/formatters/syslog_cee.rb
@@ -7,7 +7,7 @@ end
 module SemanticLogger
   module Formatters
     class SyslogCee < Raw
-      attr_accessor :level_map, :facility
+      attr_accessor :level_map, :facility, :max_size
 
       # CEE JSON Syslog format
       #   Untested prototype code. Based on documentation only.
@@ -23,9 +23,10 @@ module SemanticLogger
       # Example:
       #   # Log via udp to a remote syslog server on host: `server1` and port `8514`, using the CEE format.
       #   SemanticLogger.add_appender(appender: :syslog, formatter: syslog_cee, url: 'udp://server1:8514')
-      def initialize(facility: ::Syslog::LOG_USER, level_map: SemanticLogger::Formatters::Syslog::LevelMap.new)
+      def initialize(facility: ::Syslog::LOG_USER, level_map: SemanticLogger::Formatters::Syslog::LevelMap.new, max_size: Integer)
         @facility  = facility
         @level_map = level_map.is_a?(SemanticLogger::Formatters::Syslog::LevelMap) ? level_map : SemanticLogger::Formatters::Syslog::LevelMap.new(level_map)
+        @max_size = max_size
         super()
       end
 
@@ -49,7 +50,7 @@ module SemanticLogger
         packet.content  = message
         packet.time     = log.time
         packet.severity = level_map[log.level]
-        packet.to_s
+        packet.assemble(@max_size)
       end
     end
   end


### PR DESCRIPTION
Allow to update packet size to desired number or default it to 1024


### Changelog

Pull requests will not be accepted without a description of this change under the `[unreleased]` section 
in the file `CHANGELOG`.

### Description of changes
Instead of using the `.to_s` we use the `assemble` method to set the size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
