### PR TITLE
Add info about setting up logger with parallel Rails Minitest

### DIFF
--- a/docs/forking.md
+++ b/docs/forking.md
@@ -38,6 +38,17 @@ on_worker_boot do
 end
 ~~~
 
+### Rails with Minitest
+
+If you use [parallel tests in Rails with forking](https://guides.rubyonrails.org/testing.html#parallel-testing-with-processes), add the following to your `ActiveSupport::TestCase` class:
+
+~~~ruby
+# test/test_helper.rb
+parallelize_setup do |worker|
+  SemanticLogger.reopen
+end
+~~~
+
 ### Auto-detected Frameworks
 
 The following frameworks are automatically detected by the `Rails Semantic Logger` gem,


### PR DESCRIPTION
### Changelog

Added information about setting up Rails Minitest with Semantic Logger

### Description of changes
If you use default testing framework in Rails and parallelize tests with processes, you will get no logs unless `SemanticLogger.reopen` will be added to test case base class

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
